### PR TITLE
#215 Utføre forretningslogikken for EbmsMessageDetails.avsender felter

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailsService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailsService.kt
@@ -6,6 +6,8 @@ import no.nav.emottak.eventmanager.model.MessageInfo
 import no.nav.emottak.eventmanager.persistence.repository.EbmsMessageDetailsRepository
 import no.nav.emottak.eventmanager.persistence.repository.EventsRepository
 import no.nav.emottak.utils.kafka.model.EbmsMessageDetails
+import no.nav.emottak.utils.kafka.model.Event
+import no.nav.emottak.utils.kafka.model.EventType
 import java.time.Instant
 import java.time.ZoneId
 
@@ -28,6 +30,7 @@ class EbmsMessageDetailsService(
     suspend fun fetchEbmsMessageDetails(from: Instant, to: Instant): List<MessageInfo> {
         return ebmsMessageDetailsRepository.findByTimeInterval(from, to).map {
             val relatedEvents = eventRepository.findEventByRequestId(it.requestId)
+            val sender = it.sender ?: findSender(relatedEvents)
 
             MessageInfo(
                 datomottat = it.savedAt.atZone(ZoneId.of("Europe/Oslo")).toString(),
@@ -36,11 +39,23 @@ class EbmsMessageDetailsService(
                 service = it.service,
                 action = it.action,
                 referanse = it.refParam,
-                avsender = it.sender,
+                avsender = sender,
                 cpaid = it.cpaId,
                 antall = relatedEvents.count(),
                 status = "Unimplemented"
             )
         }
+    }
+
+    private fun findSender(events: List<Event>): String {
+        events.firstOrNull {
+            it.eventType == EventType.MESSAGE_VALIDATED_AGAINST_CPA
+        }?.let { event ->
+            val eventData = Json.decodeFromString<Map<String, String>>(event.eventData)
+            eventData["sender"]
+        }?.let { sender ->
+            return sender
+        }
+        return "Unknown"
     }
 }

--- a/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailsRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailsRepositoryTest.kt
@@ -12,7 +12,6 @@ import org.testcontainers.containers.PostgreSQLContainer
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
-import kotlin.uuid.toJavaUuid
 
 class EbmsMessageDetailsRepositoryTest : StringSpec({
 
@@ -36,9 +35,44 @@ class EbmsMessageDetailsRepositoryTest : StringSpec({
         val messageDetails = buildTestEbmsMessageDetails()
 
         repository.insert(messageDetails)
-        val retrievedDetails = repository.findByRequestId(messageDetails.requestId.toJavaUuid())
+        val retrievedDetails = repository.findByRequestId(messageDetails.requestId)
 
         retrievedDetails shouldBe messageDetails.copy()
+    }
+
+    "Should update message details by requestId" {
+        val messageDetails = buildTestEbmsMessageDetails()
+        repository.insert(messageDetails)
+
+        val updatedMessageDetails = messageDetails.copy(
+            cpaId = "updated-cpa-id",
+            conversationId = "updated-conversation-id",
+            messageId = "updated-message-id",
+            fromPartyId = "updated-from-party-id",
+            toPartyId = "updated-to-party-id",
+            service = "updated-service",
+            action = "updated-action",
+            refParam = "updated-ref-param",
+            sentAt = Instant.parse("2025-05-26T14:54:45.386Z"),
+            savedAt = Instant.parse("2025-05-26T15:54:50.386Z")
+        )
+        repository.update(updatedMessageDetails)
+
+        val retrievedDetails = repository.findByRequestId(messageDetails.requestId)
+
+        retrievedDetails?.requestId shouldBe messageDetails.requestId
+
+        retrievedDetails?.cpaId shouldBe updatedMessageDetails.cpaId
+        retrievedDetails?.conversationId shouldBe updatedMessageDetails.conversationId
+        retrievedDetails?.messageId shouldBe updatedMessageDetails.messageId
+        retrievedDetails?.requestId shouldBe updatedMessageDetails.requestId
+        retrievedDetails?.fromPartyId shouldBe updatedMessageDetails.fromPartyId
+        retrievedDetails?.toPartyId shouldBe updatedMessageDetails.toPartyId
+        retrievedDetails?.service shouldBe updatedMessageDetails.service
+        retrievedDetails?.action shouldBe updatedMessageDetails.action
+        retrievedDetails?.savedAt shouldBe updatedMessageDetails.savedAt.truncatedTo(ChronoUnit.MICROS)
+        retrievedDetails?.sentAt shouldBe updatedMessageDetails.sentAt?.truncatedTo(ChronoUnit.MICROS)
+        retrievedDetails?.refParam shouldBe updatedMessageDetails.refParam
     }
 
     "Should retrieve records by time interval" {

--- a/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailsRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailsRepositoryTest.kt
@@ -131,6 +131,7 @@ fun buildTestEbmsMessageDetails(): EbmsMessageDetails {
         toPartyId = "test-to-party-id",
         service = "test-service",
         action = "test-action",
+        sender = "test-sender",
         savedAt = Instant.now().truncatedTo(ChronoUnit.MICROS)
     )
 }

--- a/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailsServiceTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailsServiceTest.kt
@@ -1,6 +1,7 @@
 package no.nav.emottak.eventmanager.service
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -8,7 +9,9 @@ import kotlinx.serialization.json.Json
 import no.nav.emottak.eventmanager.persistence.repository.EbmsMessageDetailsRepository
 import no.nav.emottak.eventmanager.persistence.repository.EventsRepository
 import no.nav.emottak.eventmanager.repository.buildTestEbmsMessageDetails
+import no.nav.emottak.eventmanager.repository.buildTestEvent
 import no.nav.emottak.utils.kafka.model.EbmsMessageDetails
+import no.nav.emottak.utils.kafka.model.EventType
 import java.time.Instant
 
 class EbmsMessageDetailsServiceTest : StringSpec({
@@ -40,5 +43,26 @@ class EbmsMessageDetailsServiceTest : StringSpec({
         ebmsMessageDetailsService.fetchEbmsMessageDetails(from, to)
 
         coVerify { ebmsMessageDetailsRepository.findByTimeInterval(from, to) }
+    }
+
+    "Should find sender from related events" {
+        val testDetails = buildTestEbmsMessageDetails().copy(sender = null)
+        val from = Instant.now()
+        val to = from.plusSeconds(60)
+
+        val relatedEvents = listOf(
+            buildTestEvent(),
+            buildTestEvent().copy(
+                eventType = EventType.MESSAGE_VALIDATED_AGAINST_CPA,
+                eventData = Json.encodeToString(mapOf("sender" to "Test EPJ AS"))
+            )
+        )
+
+        coEvery { ebmsMessageDetailsRepository.findByTimeInterval(from, to) } returns listOf(testDetails)
+        coEvery { eventsRepository.findEventByRequestId(testDetails.requestId) } returns relatedEvents
+
+        val result = ebmsMessageDetailsService.fetchEbmsMessageDetails(from, to)
+
+        result.first().avsender shouldBe "Test EPJ AS"
     }
 })


### PR DESCRIPTION
Siden det er ingen garanti at meldingsdetaljer blir lagret før hendelser som er relaterte til meldingen, utførte jeg både:
- Oppdatering `EbmsMessageDetails.sender `ved behandling av `MESSAGE_VALIDATED_AGAINST_CPA` hendelse.
- Fylling av meldings avsender basert på relaterte hendelser ved lesing av meldingsdetaljer.