### PR TITLE
#222 Utføre forretningslogikken for EbmsMessageDetails.refParam feltet

### DIFF
--- a/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailsRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailsRepositoryTest.kt
@@ -132,6 +132,7 @@ fun buildTestEbmsMessageDetails(): EbmsMessageDetails {
         service = "test-service",
         action = "test-action",
         sender = "test-sender",
+        refParam = "test-ref-param",
         savedAt = Instant.now().truncatedTo(ChronoUnit.MICROS)
     )
 }


### PR DESCRIPTION
Siden det er ingen garanti at meldingsdetaljer blir lagret før hendelser som er relaterte til meldingen, utførte jeg både:
1. Oppdatering `EbmsMessageDetails.refParam` ved behandling av `REFERENCE_RETRIEVED `hendelse.
2. Fylling av referanse parameter basert på relaterte hendelser ved lesing av meldingsdetaljer.