### PR TITLE
#214 Utføre forretningslogikken for message info.mottakidliste feltet

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailsService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailsService.kt
@@ -11,6 +11,7 @@ import no.nav.emottak.utils.kafka.model.EventDataType
 import no.nav.emottak.utils.kafka.model.EventType
 import java.time.Instant
 import java.time.ZoneId
+import kotlin.uuid.Uuid
 
 class EbmsMessageDetailsService(
     private val eventRepository: EventsRepository,
@@ -31,11 +32,11 @@ class EbmsMessageDetailsService(
     suspend fun fetchEbmsMessageDetails(from: Instant, to: Instant): List<MessageInfo> {
         val messageDetailsList = ebmsMessageDetailsRepository.findByTimeInterval(from, to)
         val relatedRequestIds = ebmsMessageDetailsRepository.findRelatedRequestIds(messageDetailsList.map { it.requestId })
+        val relatedEvents = eventRepository.findEventsByRequestIds(messageDetailsList.map { it.requestId })
 
         return messageDetailsList.map {
-            val relatedEvents = eventRepository.findEventByRequestId(it.requestId)
-            val sender = it.sender ?: findSender(relatedEvents)
-            val refParam = it.refParam ?: findRefParam(relatedEvents)
+            val sender = it.sender ?: findSender(it.requestId, relatedEvents)
+            val refParam = it.refParam ?: findRefParam(it.requestId, relatedEvents)
 
             MessageInfo(
                 datomottat = it.savedAt.atZone(ZoneId.of("Europe/Oslo")).toString(),
@@ -52,9 +53,9 @@ class EbmsMessageDetailsService(
         }
     }
 
-    private fun findSender(events: List<Event>): String {
+    private fun findSender(requestId: Uuid, events: List<Event>): String {
         events.firstOrNull {
-            it.eventType == EventType.MESSAGE_VALIDATED_AGAINST_CPA
+            it.requestId == requestId && it.eventType == EventType.MESSAGE_VALIDATED_AGAINST_CPA
         }?.let { event ->
             val eventData = Json.decodeFromString<Map<String, String>>(event.eventData)
             eventData["sender"]
@@ -64,9 +65,9 @@ class EbmsMessageDetailsService(
         return "Unknown"
     }
 
-    private fun findRefParam(events: List<Event>): String {
+    private fun findRefParam(requestId: Uuid, events: List<Event>): String {
         events.firstOrNull {
-            it.eventType == EventType.REFERENCE_RETRIEVED
+            it.requestId == requestId && it.eventType == EventType.REFERENCE_RETRIEVED
         }?.let { event ->
             val eventData = Json.decodeFromString<Map<String, String>>(event.eventData)
             eventData[EventDataType.REFERENCE.value]

--- a/src/main/resources/db/migration/V6__added_index_for_conversation_id.sql
+++ b/src/main/resources/db/migration/V6__added_index_for_conversation_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ON "ebms_message_details" ("conversation_id");

--- a/src/main/resources/db/migration/V6__added_index_for_conversation_id.sql
+++ b/src/main/resources/db/migration/V6__added_index_for_conversation_id.sql
@@ -1,1 +1,0 @@
-CREATE INDEX ON "ebms_message_details" ("conversation_id");

--- a/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailsServiceTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailsServiceTest.kt
@@ -41,7 +41,7 @@ class EbmsMessageDetailsServiceTest : StringSpec({
         coEvery { ebmsMessageDetailsRepository.findByTimeInterval(from, to) } returns listOf(testDetails)
         coEvery { ebmsMessageDetailsRepository.findRelatedRequestIds(listOf(testDetails.requestId)) } returns
             mapOf(testDetails.requestId to testDetails.requestId.toString())
-        coEvery { eventsRepository.findEventByRequestId(testDetails.requestId) } returns listOf()
+        coEvery { eventsRepository.findEventsByRequestIds(listOf(testDetails.requestId)) } returns listOf()
 
         ebmsMessageDetailsService.fetchEbmsMessageDetails(from, to)
 
@@ -57,6 +57,7 @@ class EbmsMessageDetailsServiceTest : StringSpec({
             buildTestEvent(),
             buildTestEvent().copy(
                 eventType = EventType.MESSAGE_VALIDATED_AGAINST_CPA,
+                requestId = testDetails.requestId,
                 eventData = Json.encodeToString(mapOf("sender" to "Test EPJ AS"))
             )
         )
@@ -64,7 +65,7 @@ class EbmsMessageDetailsServiceTest : StringSpec({
         coEvery { ebmsMessageDetailsRepository.findByTimeInterval(from, to) } returns listOf(testDetails)
         coEvery { ebmsMessageDetailsRepository.findRelatedRequestIds(listOf(testDetails.requestId)) } returns
             mapOf(testDetails.requestId to testDetails.requestId.toString())
-        coEvery { eventsRepository.findEventByRequestId(testDetails.requestId) } returns relatedEvents
+        coEvery { eventsRepository.findEventsByRequestIds(listOf(testDetails.requestId)) } returns relatedEvents
 
         val result = ebmsMessageDetailsService.fetchEbmsMessageDetails(from, to)
 
@@ -81,6 +82,7 @@ class EbmsMessageDetailsServiceTest : StringSpec({
             buildTestEvent(),
             buildTestEvent().copy(
                 eventType = EventType.REFERENCE_RETRIEVED,
+                requestId = testDetails.requestId,
                 eventData = Json.encodeToString(mapOf(EventDataType.REFERENCE.value to reference))
             )
         )
@@ -88,7 +90,7 @@ class EbmsMessageDetailsServiceTest : StringSpec({
         coEvery { ebmsMessageDetailsRepository.findByTimeInterval(from, to) } returns listOf(testDetails)
         coEvery { ebmsMessageDetailsRepository.findRelatedRequestIds(listOf(testDetails.requestId)) } returns
             mapOf(testDetails.requestId to testDetails.requestId.toString())
-        coEvery { eventsRepository.findEventByRequestId(testDetails.requestId) } returns relatedEvents
+        coEvery { eventsRepository.findEventsByRequestIds(listOf(testDetails.requestId)) } returns relatedEvents
 
         val result = ebmsMessageDetailsService.fetchEbmsMessageDetails(from, to)
 
@@ -115,9 +117,11 @@ class EbmsMessageDetailsServiceTest : StringSpec({
                 testDetails2.requestId to "${testDetails1.requestId},${testDetails2.requestId}",
                 testDetails3.requestId to "${testDetails3.requestId}"
             )
-        coEvery { eventsRepository.findEventByRequestId(testDetails1.requestId) } returns listOf()
-        coEvery { eventsRepository.findEventByRequestId(testDetails2.requestId) } returns listOf()
-        coEvery { eventsRepository.findEventByRequestId(testDetails3.requestId) } returns listOf()
+        coEvery {
+            eventsRepository.findEventsByRequestIds(
+                listOf(testDetails1.requestId, testDetails2.requestId, testDetails3.requestId)
+            )
+        } returns listOf()
 
         val result = ebmsMessageDetailsService.fetchEbmsMessageDetails(from, to)
 


### PR DESCRIPTION
1. Utført forretningslogikken for `MessageInfo.mottakidliste` feltet. Det inneholder ei liste med `requestId `til andre meldinger som har det samme `conversationId `som denne meldingen.
2. Refaktorisert `fetchEbmsMessageDetails()` method for å unngå _n+1_ forespørsler til database.