### PR TITLE
 #241 Opprette utvidbare modeller for Event Manager

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/model/EbmsMessageDetail.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/model/EbmsMessageDetail.kt
@@ -1,0 +1,47 @@
+package no.nav.emottak.eventmanager.model
+
+import java.time.Instant
+import kotlin.uuid.Uuid
+import no.nav.emottak.utils.kafka.model.EbmsMessageDetail as TransportEbmsMessageDetail
+
+data class EbmsMessageDetail(
+    // Basic fields
+    val requestId: Uuid,
+    val cpaId: String,
+    val conversationId: String,
+    val messageId: String,
+    val refToMessageId: String? = null,
+    val fromPartyId: String,
+    val fromRole: String? = null,
+    val toPartyId: String,
+    val toRole: String? = null,
+    val service: String,
+    val action: String,
+    val sentAt: Instant? = null,
+    val savedAt: Instant,
+
+    // Extra fields
+    val sender: String? = null,
+    val refParam: String? = null,
+    val mottakId: String? = null
+) {
+    companion object {
+        fun fromTransportModel(transportEbmsMessageDetail: TransportEbmsMessageDetail): EbmsMessageDetail {
+            return EbmsMessageDetail(
+                requestId = transportEbmsMessageDetail.requestId,
+                cpaId = transportEbmsMessageDetail.cpaId,
+                conversationId = transportEbmsMessageDetail.conversationId,
+                messageId = transportEbmsMessageDetail.messageId,
+                refToMessageId = transportEbmsMessageDetail.refToMessageId,
+                fromPartyId = transportEbmsMessageDetail.fromPartyId,
+                fromRole = transportEbmsMessageDetail.fromRole,
+                toPartyId = transportEbmsMessageDetail.toPartyId,
+                toRole = transportEbmsMessageDetail.toRole,
+                service = transportEbmsMessageDetail.service,
+                action = transportEbmsMessageDetail.action,
+                sentAt = transportEbmsMessageDetail.sentAt,
+                savedAt = transportEbmsMessageDetail.savedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/emottak/eventmanager/model/Event.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/model/Event.kt
@@ -1,0 +1,28 @@
+package no.nav.emottak.eventmanager.model
+
+import no.nav.emottak.utils.kafka.model.EventType
+import java.time.Instant
+import kotlin.uuid.Uuid
+import no.nav.emottak.utils.kafka.model.Event as TransportEvent
+
+data class Event(
+    val eventType: EventType,
+    val requestId: Uuid,
+    val contentId: String? = null,
+    val messageId: String,
+    val eventData: String,
+    val createdAt: Instant
+) {
+    companion object {
+        fun fromTransportModel(transportEvent: TransportEvent): Event {
+            return Event(
+                eventType = transportEvent.eventType,
+                requestId = transportEvent.requestId,
+                contentId = transportEvent.contentId,
+                messageId = transportEvent.messageId,
+                eventData = transportEvent.eventData,
+                createdAt = transportEvent.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
@@ -2,6 +2,7 @@ package no.nav.emottak.eventmanager.persistence.repository
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import no.nav.emottak.eventmanager.model.EbmsMessageDetail
 import no.nav.emottak.eventmanager.persistence.Database
 import no.nav.emottak.eventmanager.persistence.table.EbmsMessageDetailTable
 import no.nav.emottak.eventmanager.persistence.table.EbmsMessageDetailTable.action
@@ -19,7 +20,6 @@ import no.nav.emottak.eventmanager.persistence.table.EbmsMessageDetailTable.sent
 import no.nav.emottak.eventmanager.persistence.table.EbmsMessageDetailTable.service
 import no.nav.emottak.eventmanager.persistence.table.EbmsMessageDetailTable.toPartyId
 import no.nav.emottak.eventmanager.persistence.table.EbmsMessageDetailTable.toRole
-import no.nav.emottak.utils.kafka.model.EbmsMessageDetail
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.TextColumnType
 import org.jetbrains.exposed.sql.alias

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EventRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EventRepository.kt
@@ -3,6 +3,7 @@ package no.nav.emottak.eventmanager.persistence.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import no.nav.emottak.eventmanager.model.Event
 import no.nav.emottak.eventmanager.persistence.Database
 import no.nav.emottak.eventmanager.persistence.table.EventTable
 import no.nav.emottak.eventmanager.persistence.table.EventTable.contentId
@@ -10,7 +11,6 @@ import no.nav.emottak.eventmanager.persistence.table.EventTable.createdAt
 import no.nav.emottak.eventmanager.persistence.table.EventTable.eventData
 import no.nav.emottak.eventmanager.persistence.table.EventTable.eventTypeId
 import no.nav.emottak.eventmanager.persistence.table.EventTable.messageId
-import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventType
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.transaction

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
@@ -2,19 +2,20 @@ package no.nav.emottak.eventmanager.service
 
 import kotlinx.serialization.json.Json
 import no.nav.emottak.eventmanager.log
+import no.nav.emottak.eventmanager.model.EbmsMessageDetail
+import no.nav.emottak.eventmanager.model.Event
 import no.nav.emottak.eventmanager.model.MessageInfo
 import no.nav.emottak.eventmanager.model.MottakIdInfo
 import no.nav.emottak.eventmanager.persistence.repository.EbmsMessageDetailRepository
 import no.nav.emottak.eventmanager.persistence.repository.EventRepository
 import no.nav.emottak.eventmanager.persistence.repository.EventTypeRepository
 import no.nav.emottak.eventmanager.persistence.table.EventStatusEnum
-import no.nav.emottak.utils.kafka.model.EbmsMessageDetail
-import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventDataType
 import no.nav.emottak.utils.kafka.model.EventType
 import java.time.Instant
 import java.time.ZoneId
 import kotlin.uuid.Uuid
+import no.nav.emottak.utils.kafka.model.EbmsMessageDetail as TransportEbmsMessageDetail
 
 class EbmsMessageDetailService(
     private val eventRepository: EventRepository,
@@ -25,9 +26,10 @@ class EbmsMessageDetailService(
         try {
             log.info("EBMS message details read from Kafka: ${String(value)}")
 
-            val details: EbmsMessageDetail = Json.decodeFromString(String(value))
-            ebmsMessageDetailRepository.insert(details)
-            log.info("EBMS message details processed successfully: $details")
+            val transportEbmsMessageDetail: TransportEbmsMessageDetail = Json.decodeFromString(String(value))
+            val ebmsMessageDetail: EbmsMessageDetail = EbmsMessageDetail.fromTransportModel(transportEbmsMessageDetail)
+            ebmsMessageDetailRepository.insert(ebmsMessageDetail)
+            log.info("EBMS message details processed successfully: $ebmsMessageDetail")
         } catch (e: Exception) {
             log.error("Exception while processing EBMS message details:${String(value)}", e)
         }

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
@@ -2,16 +2,17 @@ package no.nav.emottak.eventmanager.service
 
 import kotlinx.serialization.json.Json
 import no.nav.emottak.eventmanager.log
+import no.nav.emottak.eventmanager.model.Event
 import no.nav.emottak.eventmanager.model.EventInfo
 import no.nav.emottak.eventmanager.model.MessageLoggInfo
 import no.nav.emottak.eventmanager.persistence.repository.EbmsMessageDetailRepository
 import no.nav.emottak.eventmanager.persistence.repository.EventRepository
-import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventDataType
 import no.nav.emottak.utils.kafka.model.EventType
 import java.time.Instant
 import java.time.ZoneId
 import kotlin.uuid.Uuid
+import no.nav.emottak.utils.kafka.model.Event as TransportEvent
 
 class EventService(
     private val eventRepository: EventRepository,
@@ -20,7 +21,8 @@ class EventService(
     suspend fun process(value: ByteArray) {
         try {
             log.info("Event read from Kafka: ${String(value)}")
-            val event: Event = Json.decodeFromString(String(value))
+            val transportEvent: TransportEvent = Json.decodeFromString(String(value))
+            val event = Event.fromTransportModel(transportEvent)
 
             updateMessageDetails(event)
 

--- a/src/test/kotlin/no/nav/emottak/eventmanager/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/ApplicationTest.kt
@@ -211,8 +211,8 @@ class ApplicationTest : StringSpec({
             messageInfoList[0].role shouldBe messageDetails.fromRole
             messageInfoList[0].service shouldBe messageDetails.service
             messageInfoList[0].action shouldBe messageDetails.action
-            messageInfoList[0].referanse shouldBe messageDetails.refParam
-            messageInfoList[0].avsender shouldBe messageDetails.sender
+            messageInfoList[0].referanse shouldBe "Unknown"
+            messageInfoList[0].avsender shouldBe "Unknown"
             messageInfoList[0].cpaid shouldBe messageDetails.cpaId
             messageInfoList[0].antall shouldBe 1
             messageInfoList[0].status shouldBe "Meldingen er under behandling"
@@ -460,8 +460,8 @@ class ApplicationTest : StringSpec({
             messageInfoList[0].role shouldBe messageDetails.fromRole
             messageInfoList[0].service shouldBe messageDetails.service
             messageInfoList[0].action shouldBe messageDetails.action
-            messageInfoList[0].referanse shouldBe messageDetails.refParam
-            messageInfoList[0].avsender shouldBe messageDetails.sender
+            messageInfoList[0].referanse shouldBe "Unknown"
+            messageInfoList[0].avsender shouldBe "Unknown"
             messageInfoList[0].cpaid shouldBe messageDetails.cpaId
             messageInfoList[0].status shouldBe "Meldingen er under behandling"
         }

--- a/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailRepositoryTest.kt
@@ -5,14 +5,15 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.maps.shouldContainKey
 import io.kotest.matchers.shouldBe
+import no.nav.emottak.eventmanager.model.EbmsMessageDetail
 import no.nav.emottak.eventmanager.persistence.Database
 import no.nav.emottak.eventmanager.persistence.EVENT_DB_NAME
 import no.nav.emottak.eventmanager.persistence.repository.EbmsMessageDetailRepository
-import no.nav.emottak.utils.kafka.model.EbmsMessageDetail
 import org.testcontainers.containers.PostgreSQLContainer
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
+import no.nav.emottak.utils.kafka.model.EbmsMessageDetail as TransportEbmsMessageDetail
 
 class EbmsMessageDetailRepositoryTest : StringSpec({
 
@@ -185,7 +186,11 @@ class EbmsMessageDetailRepositoryTest : StringSpec({
 }
 
 fun buildTestEbmsMessageDetail(): EbmsMessageDetail {
-    return EbmsMessageDetail(
+    return EbmsMessageDetail.fromTransportModel(buildTestTransportMessageDetail())
+}
+
+fun buildTestTransportMessageDetail(): TransportEbmsMessageDetail {
+    return TransportEbmsMessageDetail(
         requestId = Uuid.random(),
         cpaId = "test-cpa-id",
         conversationId = "test-conversation-id",
@@ -196,8 +201,6 @@ fun buildTestEbmsMessageDetail(): EbmsMessageDetail {
         toRole = "test-to-role",
         service = "test-service",
         action = "test-action",
-        refParam = "test-ref-param",
-        sender = "test-sender",
         savedAt = Instant.parse("2025-05-08T12:54:45.386Z")
     )
 }

--- a/src/test/kotlin/no/nav/emottak/eventmanager/repository/EventRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/repository/EventRepositoryTest.kt
@@ -5,14 +5,15 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import no.nav.emottak.eventmanager.model.Event
 import no.nav.emottak.eventmanager.persistence.Database
 import no.nav.emottak.eventmanager.persistence.EVENT_DB_NAME
 import no.nav.emottak.eventmanager.persistence.repository.EventRepository
-import no.nav.emottak.utils.kafka.model.Event
 import no.nav.emottak.utils.kafka.model.EventType
 import org.testcontainers.containers.PostgreSQLContainer
 import java.time.Instant
 import kotlin.uuid.Uuid
+import no.nav.emottak.utils.kafka.model.Event as TransportEvent
 
 class EventRepositoryTest : StringSpec({
 
@@ -49,12 +50,11 @@ class EventRepositoryTest : StringSpec({
     }
 
     "Should retrieve an event with empty eventData by eventId" {
-        val testEvent = Event(
-            eventType = EventType.MESSAGE_SAVED_IN_JURIDISK_LOGG,
-            requestId = Uuid.random(),
-            contentId = "test-content-id",
-            messageId = "test-message-id"
+        val testTransportEvent = buildTestTransportEvent().copy(
+            eventData = "{}"
         )
+
+        val testEvent = Event.fromTransportModel(testTransportEvent)
 
         val eventId = eventRepository.insert(testEvent)
         val retrievedEvent = eventRepository.findEventById(eventId)
@@ -128,7 +128,11 @@ class EventRepositoryTest : StringSpec({
     }
 }
 
-fun buildTestEvent(): Event = Event(
+fun buildTestEvent(): Event {
+    return Event.fromTransportModel(buildTestTransportEvent())
+}
+
+fun buildTestTransportEvent(): TransportEvent = TransportEvent(
     eventType = EventType.MESSAGE_SAVED_IN_JURIDISK_LOGG,
     requestId = Uuid.random(),
     contentId = "test-content-id",

--- a/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailServiceTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.serialization.json.Json
+import no.nav.emottak.eventmanager.model.EbmsMessageDetail
 import no.nav.emottak.eventmanager.model.EventType
 import no.nav.emottak.eventmanager.persistence.repository.EbmsMessageDetailRepository
 import no.nav.emottak.eventmanager.persistence.repository.EventRepository
@@ -13,10 +14,11 @@ import no.nav.emottak.eventmanager.persistence.repository.EventTypeRepository
 import no.nav.emottak.eventmanager.persistence.table.EventStatusEnum
 import no.nav.emottak.eventmanager.repository.buildTestEbmsMessageDetail
 import no.nav.emottak.eventmanager.repository.buildTestEvent
-import no.nav.emottak.utils.kafka.model.EbmsMessageDetail
+import no.nav.emottak.eventmanager.repository.buildTestTransportMessageDetail
 import no.nav.emottak.utils.kafka.model.EventDataType
 import java.time.Instant
 import kotlin.uuid.Uuid
+import no.nav.emottak.utils.kafka.model.EbmsMessageDetail as TransportEbmsMessageDetail
 import no.nav.emottak.utils.kafka.model.EventType as EventTypeEnum
 
 class EbmsMessageDetailServiceTest : StringSpec({
@@ -28,8 +30,10 @@ class EbmsMessageDetailServiceTest : StringSpec({
 
     "Should call database repository on processing EBMS message details" {
 
-        val testDetails = buildTestEbmsMessageDetail()
-        val testDetailsJson = Json.encodeToString(EbmsMessageDetail.serializer(), testDetails)
+        val testTransportMessageDetail = buildTestTransportMessageDetail()
+        val testDetailsJson = Json.encodeToString(TransportEbmsMessageDetail.serializer(), testTransportMessageDetail)
+
+        val testDetails = EbmsMessageDetail.fromTransportModel(testTransportMessageDetail)
 
         coEvery { ebmsMessageDetailRepository.insert(testDetails) } returns testDetails.requestId
 

--- a/src/test/kotlin/no/nav/emottak/eventmanager/service/EventServiceTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/service/EventServiceTest.kt
@@ -5,9 +5,11 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import no.nav.emottak.eventmanager.model.Event
 import no.nav.emottak.eventmanager.persistence.repository.EbmsMessageDetailRepository
 import no.nav.emottak.eventmanager.persistence.repository.EventRepository
 import no.nav.emottak.eventmanager.repository.buildTestEvent
+import no.nav.emottak.eventmanager.repository.buildTestTransportEvent
 import java.time.Instant
 import java.time.ZoneId
 
@@ -19,11 +21,12 @@ class EventServiceTest : StringSpec({
 
     "Should call database repository on processing en event" {
 
-        val testEvent = buildTestEvent()
+        val testTransportEvent = buildTestTransportEvent()
+        val testEvent = Event.fromTransportModel(testTransportEvent)
 
         coEvery { eventRepository.insert(testEvent) } returns testEvent.requestId
 
-        eventService.process(testEvent.toByteArray())
+        eventService.process(testTransportEvent.toByteArray())
 
         coVerify { eventRepository.insert(testEvent) }
     }


### PR DESCRIPTION
Nå har `emottak-event-manager` sine egne utførelser ev `EbmsMessageDetail` og `Event ` modellene.

Oppgave: https://github.com/navikt/team-emottak-docs/issues/241