### PR TITLE
246 Utforske tidsavbruddsfeil ved visning av data fra det nye eMottak

### DIFF
--- a/.nais/emottak-event-manager-prod.yaml
+++ b/.nais/emottak-event-manager-prod.yaml
@@ -42,11 +42,10 @@ spec:
     max: 1
   resources:
     limits:
-      cpu: "1000m"
-      memory: "512Mi"
+      memory: "1024Mi"
     requests:
-      cpu: "100m"
-      memory: "256Mi"
+      cpu: "500m"
+      memory: "512Mi"
   ingresses:
     - "https://emottak-event-manager.intern.nav.no"
   vault:

--- a/.nais/emottak-event-manager-prod.yaml
+++ b/.nais/emottak-event-manager-prod.yaml
@@ -44,7 +44,7 @@ spec:
     limits:
       memory: "1024Mi"
     requests:
-      cpu: "500m"
+      cpu: "300m"
       memory: "512Mi"
   ingresses:
     - "https://emottak-event-manager.intern.nav.no"

--- a/src/main/kotlin/no/nav/emottak/eventmanager/Routing.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/Routing.kt
@@ -40,7 +40,7 @@ fun Application.configureRouting(
             call.respond(events)
 
             val endTime = System.currentTimeMillis()
-            log.info("Processing time diapason $fromDate - $toDate in /fetchevents : ${endTime - startTime} ms")
+            log.info("Profiling: Processing time for time diapason $fromDate - $toDate in /fetchevents : ${endTime - startTime} ms")
         }
 
         get("/fetchMessageDetails") {
@@ -59,7 +59,7 @@ fun Application.configureRouting(
             call.respond(messageDetails)
 
             val endTime = System.currentTimeMillis()
-            log.info("Processing time diapason $fromDate - $toDate in /fetchMessageDetails : ${endTime - startTime} ms")
+            log.info("Profiling: Processing time for time diapason $fromDate - $toDate in /fetchMessageDetails : ${endTime - startTime} ms")
         }
 
         get("/fetchMessageLoggInfo") {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/Routing.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/Routing.kt
@@ -25,6 +25,8 @@ fun Application.configureRouting(
             call.respondText("Hello World!")
         }
         get("/fetchevents") {
+            val startTime = System.currentTimeMillis()
+
             if (!Validation.validateDateRangeRequest(call)) return@get
 
             val fromDate = Validation.parseDate(call.request.queryParameters["fromDate"]!!)
@@ -36,9 +38,14 @@ fun Application.configureRouting(
             log.debug("The last event: ${events.lastOrNull()}")
 
             call.respond(events)
+
+            val endTime = System.currentTimeMillis()
+            log.info("Processing time diapason $fromDate - $toDate in /fetchevents : ${endTime - startTime} ms")
         }
 
         get("/fetchMessageDetails") {
+            val startTime = System.currentTimeMillis()
+
             if (!Validation.validateDateRangeRequest(call)) return@get
 
             val fromDate = Validation.parseDate(call.request.queryParameters["fromDate"]!!)
@@ -50,6 +57,9 @@ fun Application.configureRouting(
             log.debug("The last message details retrieved: ${messageDetails.lastOrNull()}")
 
             call.respond(messageDetails)
+
+            val endTime = System.currentTimeMillis()
+            log.info("Processing time diapason $fromDate - $toDate in /fetchMessageDetails : ${endTime - startTime} ms")
         }
 
         get("/fetchMessageLoggInfo") {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/Routing.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/Routing.kt
@@ -25,8 +25,6 @@ fun Application.configureRouting(
             call.respondText("Hello World!")
         }
         get("/fetchevents") {
-            val startTime = System.currentTimeMillis()
-
             if (!Validation.validateDateRangeRequest(call)) return@get
 
             val fromDate = Validation.parseDate(call.request.queryParameters["fromDate"]!!)
@@ -38,14 +36,9 @@ fun Application.configureRouting(
             log.debug("The last event: ${events.lastOrNull()}")
 
             call.respond(events)
-
-            val endTime = System.currentTimeMillis()
-            log.info("Profiling: Processing time for time diapason $fromDate - $toDate in /fetchevents : ${endTime - startTime} ms")
         }
 
         get("/fetchMessageDetails") {
-            val startTime = System.currentTimeMillis()
-
             if (!Validation.validateDateRangeRequest(call)) return@get
 
             val fromDate = Validation.parseDate(call.request.queryParameters["fromDate"]!!)
@@ -57,9 +50,6 @@ fun Application.configureRouting(
             log.debug("The last message details retrieved: ${messageDetails.lastOrNull()}")
 
             call.respond(messageDetails)
-
-            val endTime = System.currentTimeMillis()
-            log.info("Profiling: Processing time for time diapason $fromDate - $toDate in /fetchMessageDetails : ${endTime - startTime} ms")
         }
 
         get("/fetchMessageLoggInfo") {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
@@ -269,7 +269,7 @@ class EbmsMessageDetailRepository(private val database: Database) {
                 .alias("related")
 
             EbmsMessageDetailTable
-                .join(subQuery, JoinType.INNER, conversationId, subQuery[conversationId])
+                .join(subQuery, JoinType.LEFT, conversationId, subQuery[conversationId])
                 .select(requestId, subQuery[relatedMottakIdsColumn])
                 .where { requestId.inList(requestIds.map { it.toJavaUuid() }) }
                 .mapNotNull {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
@@ -207,11 +207,12 @@ class EbmsMessageDetailRepository(private val database: Database) {
         }
     }
 
-    suspend fun findByTimeInterval(from: Instant, to: Instant): List<EbmsMessageDetail> = withContext(Dispatchers.IO) {
+    suspend fun findByTimeInterval(from: Instant, to: Instant, limit: Int = 1000): List<EbmsMessageDetail> = withContext(Dispatchers.IO) {
         transaction {
             EbmsMessageDetailTable
                 .select(EbmsMessageDetailTable.columns)
                 .where { savedAt.between(from, to) }
+                .limit(limit)
                 .mapNotNull {
                     EbmsMessageDetail(
                         requestId = it[requestId].toKotlinUuid(),

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
@@ -147,12 +147,14 @@ class EbmsMessageDetailRepository(private val database: Database) {
         }
     }
 
-    suspend fun findByMottakIdPattern(mottakIdPattern: String): EbmsMessageDetail? = withContext(Dispatchers.IO) {
+    suspend fun findByMottakIdPattern(mottakIdPattern: String, limit: Int? = null): EbmsMessageDetail? = withContext(Dispatchers.IO) {
         transaction {
             EbmsMessageDetailTable
                 .select(EbmsMessageDetailTable.columns)
                 .where { mottakId.lowerCase() like "%$mottakIdPattern%".lowercase() }
-                .limit(100)
+                .apply {
+                    if (limit != null) this.limit(limit)
+                }
                 .mapNotNull {
                     EbmsMessageDetail(
                         requestId = it[requestId].toKotlinUuid(),
@@ -207,12 +209,14 @@ class EbmsMessageDetailRepository(private val database: Database) {
         }
     }
 
-    suspend fun findByTimeInterval(from: Instant, to: Instant, limit: Int = 1000): List<EbmsMessageDetail> = withContext(Dispatchers.IO) {
+    suspend fun findByTimeInterval(from: Instant, to: Instant, limit: Int? = null): List<EbmsMessageDetail> = withContext(Dispatchers.IO) {
         transaction {
             EbmsMessageDetailTable
                 .select(EbmsMessageDetailTable.columns)
                 .where { savedAt.between(from, to) }
-                .limit(limit)
+                .apply {
+                    if (limit != null) this.limit(limit)
+                }
                 .mapNotNull {
                     EbmsMessageDetail(
                         requestId = it[requestId].toKotlinUuid(),

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EbmsMessageDetailRepository.kt
@@ -269,7 +269,7 @@ class EbmsMessageDetailRepository(private val database: Database) {
                 .alias("related")
 
             EbmsMessageDetailTable
-                .join(subQuery, JoinType.LEFT, conversationId, subQuery[conversationId])
+                .join(subQuery, JoinType.INNER, conversationId, subQuery[conversationId])
                 .select(requestId, subQuery[relatedMottakIdsColumn])
                 .where { requestId.inList(requestIds.map { it.toJavaUuid() }) }
                 .mapNotNull {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EventRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EventRepository.kt
@@ -94,10 +94,11 @@ class EventRepository(private val database: Database) {
         }
     }
 
-    suspend fun findEventByTimeInterval(from: Instant, to: Instant): List<Event> = withContext(Dispatchers.IO) {
+    suspend fun findEventByTimeInterval(from: Instant, to: Instant, limit: Int = 1000): List<Event> = withContext(Dispatchers.IO) {
         transaction {
             EventTable.select(EventTable.columns)
                 .where { createdAt.between(from, to) }
+                .limit(limit)
                 .mapNotNull {
                     Event(
                         eventType = EventType.fromInt(it[eventTypeId]),

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EventRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/EventRepository.kt
@@ -94,11 +94,13 @@ class EventRepository(private val database: Database) {
         }
     }
 
-    suspend fun findEventByTimeInterval(from: Instant, to: Instant, limit: Int = 1000): List<Event> = withContext(Dispatchers.IO) {
+    suspend fun findEventByTimeInterval(from: Instant, to: Instant, limit: Int? = null): List<Event> = withContext(Dispatchers.IO) {
         transaction {
             EventTable.select(EventTable.columns)
                 .where { createdAt.between(from, to) }
-                .limit(limit)
+                .apply {
+                    if (limit != null) this.limit(limit)
+                }
                 .mapNotNull {
                     Event(
                         eventType = EventType.fromInt(it[eventTypeId]),

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
@@ -40,13 +40,15 @@ class EbmsMessageDetailService(
         val startTime = System.currentTimeMillis()
 
         val messageDetailsList = ebmsMessageDetailRepository.findByTimeInterval(from, to)
-        log.info("Profiling: findByTimeInterval executed in ${System.currentTimeMillis() - startTime} ms")
+        val step1 = System.currentTimeMillis()
+        log.info("Profiling: findByTimeInterval executed in ${step1 - startTime} ms")
 
         val relatedMottakIds = ebmsMessageDetailRepository.findRelatedMottakIds(messageDetailsList.map { it.requestId })
-        log.info("Profiling: findRelatedMottakIds executed in ${System.currentTimeMillis() - startTime} ms")
+        val step2 = System.currentTimeMillis()
+        log.info("Profiling: findRelatedMottakIds executed in ${step2 - step1} ms")
 
         val relatedEvents = eventRepository.findEventsByRequestIds(messageDetailsList.map { it.requestId })
-        log.info("Profiling: findEventsByRequestIds executed in ${System.currentTimeMillis() - startTime} ms")
+        log.info("Profiling: findEventsByRequestIds executed in ${System.currentTimeMillis() - step2} ms")
 
         return messageDetailsList.map {
             val sender = it.sender ?: findSender(it.requestId, relatedEvents)

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
@@ -37,9 +37,16 @@ class EbmsMessageDetailService(
     }
 
     suspend fun fetchEbmsMessageDetails(from: Instant, to: Instant): List<MessageInfo> {
+        val startTime = System.currentTimeMillis()
+
         val messageDetailsList = ebmsMessageDetailRepository.findByTimeInterval(from, to)
+        log.info("Profiling: findByTimeInterval executed in ${System.currentTimeMillis() - startTime} ms")
+
         val relatedMottakIds = ebmsMessageDetailRepository.findRelatedMottakIds(messageDetailsList.map { it.requestId })
+        log.info("Profiling: findRelatedMottakIds executed in ${System.currentTimeMillis() - startTime} ms")
+
         val relatedEvents = eventRepository.findEventsByRequestIds(messageDetailsList.map { it.requestId })
+        log.info("Profiling: findEventsByRequestIds executed in ${System.currentTimeMillis() - startTime} ms")
 
         return messageDetailsList.map {
             val sender = it.sender ?: findSender(it.requestId, relatedEvents)

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
@@ -37,7 +37,7 @@ class EbmsMessageDetailService(
     }
 
     suspend fun fetchEbmsMessageDetails(from: Instant, to: Instant): List<MessageInfo> {
-        val messageDetailsList = ebmsMessageDetailRepository.findByTimeInterval(from, to)
+        val messageDetailsList = ebmsMessageDetailRepository.findByTimeInterval(from, to, 1000)
         val relatedMottakIds = ebmsMessageDetailRepository.findRelatedMottakIds(messageDetailsList.map { it.requestId })
         val relatedEvents = eventRepository.findEventsByRequestIds(messageDetailsList.map { it.requestId })
 
@@ -68,7 +68,7 @@ class EbmsMessageDetailService(
             ebmsMessageDetailRepository.findByRequestId(Uuid.parse(id))
         } else {
             log.info("Fetching message details by Mottak ID: $id")
-            ebmsMessageDetailRepository.findByMottakIdPattern(id)
+            ebmsMessageDetailRepository.findByMottakIdPattern(id, 1000)
         }
 
         if (messageDetails == null) {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
@@ -37,18 +37,9 @@ class EbmsMessageDetailService(
     }
 
     suspend fun fetchEbmsMessageDetails(from: Instant, to: Instant): List<MessageInfo> {
-        val startTime = System.currentTimeMillis()
-
         val messageDetailsList = ebmsMessageDetailRepository.findByTimeInterval(from, to)
-        val step1 = System.currentTimeMillis()
-        log.info("Profiling: findByTimeInterval executed in ${step1 - startTime} ms")
-
         val relatedMottakIds = ebmsMessageDetailRepository.findRelatedMottakIds(messageDetailsList.map { it.requestId })
-        val step2 = System.currentTimeMillis()
-        log.info("Profiling: findRelatedMottakIds executed in ${step2 - step1} ms")
-
         val relatedEvents = eventRepository.findEventsByRequestIds(messageDetailsList.map { it.requestId })
-        log.info("Profiling: findEventsByRequestIds executed in ${System.currentTimeMillis() - step2} ms")
 
         return messageDetailsList.map {
             val sender = it.sender ?: findSender(it.requestId, relatedEvents)

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
@@ -35,15 +35,9 @@ class EventService(
     }
 
     suspend fun fetchEvents(from: Instant, to: Instant): List<EventInfo> {
-        val startTime = System.currentTimeMillis()
-
         val eventsList = eventRepository.findEventByTimeInterval(from, to)
-        val step1 = System.currentTimeMillis()
-        log.info("Profiling: findEventByTimeInterval executed in ${step1 - startTime} ms")
-
         val requestIds = eventsList.map { it.requestId }.distinct()
         val messageDetailsMap = ebmsMessageDetailRepository.findByRequestIds(requestIds)
-        log.info("Profiling: findByRequestIds executed in ${System.currentTimeMillis() - step1} ms")
 
         return eventsList.map {
             val ebmsMessageDetail = messageDetailsMap[it.requestId]

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
@@ -38,11 +38,12 @@ class EventService(
         val startTime = System.currentTimeMillis()
 
         val eventsList = eventRepository.findEventByTimeInterval(from, to)
-        log.info("Profiling: findEventByTimeInterval executed in ${System.currentTimeMillis() - startTime} ms")
+        val step1 = System.currentTimeMillis()
+        log.info("Profiling: findEventByTimeInterval executed in ${step1 - startTime} ms")
 
         val requestIds = eventsList.map { it.requestId }.distinct()
         val messageDetailsMap = ebmsMessageDetailRepository.findByRequestIds(requestIds)
-        log.info("Profiling: findByRequestIds executed in ${System.currentTimeMillis() - startTime} ms")
+        log.info("Profiling: findByRequestIds executed in ${System.currentTimeMillis() - step1} ms")
 
         return eventsList.map {
             val ebmsMessageDetail = messageDetailsMap[it.requestId]

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
@@ -35,7 +35,7 @@ class EventService(
     }
 
     suspend fun fetchEvents(from: Instant, to: Instant): List<EventInfo> {
-        val eventsList = eventRepository.findEventByTimeInterval(from, to)
+        val eventsList = eventRepository.findEventByTimeInterval(from, to, 1000)
         val requestIds = eventsList.map { it.requestId }.distinct()
         val messageDetailsMap = ebmsMessageDetailRepository.findByRequestIds(requestIds)
 

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
@@ -35,9 +35,14 @@ class EventService(
     }
 
     suspend fun fetchEvents(from: Instant, to: Instant): List<EventInfo> {
+        val startTime = System.currentTimeMillis()
+
         val eventsList = eventRepository.findEventByTimeInterval(from, to)
+        log.info("Profiling: findEventByTimeInterval executed in ${System.currentTimeMillis() - startTime} ms")
+
         val requestIds = eventsList.map { it.requestId }.distinct()
         val messageDetailsMap = ebmsMessageDetailRepository.findByRequestIds(requestIds)
+        log.info("Profiling: findByRequestIds executed in ${System.currentTimeMillis() - startTime} ms")
 
         return eventsList.map {
             val ebmsMessageDetail = messageDetailsMap[it.requestId]

--- a/src/main/resources/db/migration/V8__create_index_on_conversation_id.sql
+++ b/src/main/resources/db/migration/V8__create_index_on_conversation_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "ebms_message_details_conversation_id_idx" ON "ebms_message_details" ("conversation_id");

--- a/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailServiceTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailServiceTest.kt
@@ -53,7 +53,7 @@ class EbmsMessageDetailServiceTest : StringSpec({
         val from = Instant.now()
         val to = from.plusSeconds(60)
 
-        coEvery { ebmsMessageDetailRepository.findByTimeInterval(from, to) } returns listOf(testDetails)
+        coEvery { ebmsMessageDetailRepository.findByTimeInterval(from, to, any()) } returns listOf(testDetails)
         coEvery { eventTypeRepository.findEventTypesByIds(listOf(testEvent.eventType.value)) } returns listOf(testEventType)
 
         coEvery { ebmsMessageDetailRepository.findRelatedMottakIds(listOf(testDetails.requestId)) } returns
@@ -62,7 +62,7 @@ class EbmsMessageDetailServiceTest : StringSpec({
 
         val messageInfoList = ebmsMessageDetailService.fetchEbmsMessageDetails(from, to)
 
-        coVerify { ebmsMessageDetailRepository.findByTimeInterval(from, to) }
+        coVerify { ebmsMessageDetailRepository.findByTimeInterval(from, to, 1000) }
         coVerify { eventTypeRepository.findEventTypesByIds(listOf(testEvent.eventType.value)) }
 
         messageInfoList.size shouldBe 1
@@ -110,13 +110,13 @@ class EbmsMessageDetailServiceTest : StringSpec({
             status = EventStatusEnum.INFORMATION
         )
 
-        coEvery { ebmsMessageDetailRepository.findByMottakIdPattern(testDetails.calculateMottakId()) } returns testDetails
+        coEvery { ebmsMessageDetailRepository.findByMottakIdPattern(testDetails.calculateMottakId(), any()) } returns testDetails
         coEvery { eventRepository.findEventsByRequestId(testDetails.requestId) } returns listOf(testEvent)
         coEvery { eventTypeRepository.findEventTypesByIds(listOf(testEvent.eventType.value)) } returns listOf(testEventType)
 
         val mottakIdInfoList = ebmsMessageDetailService.fetchEbmsMessageDetails(testDetails.calculateMottakId())
 
-        coVerify { ebmsMessageDetailRepository.findByMottakIdPattern(testDetails.calculateMottakId()) }
+        coVerify { ebmsMessageDetailRepository.findByMottakIdPattern(testDetails.calculateMottakId(), 1000) }
         coVerify { eventRepository.findEventsByRequestId(testDetails.requestId) }
 
         mottakIdInfoList.size shouldBe 1
@@ -138,7 +138,7 @@ class EbmsMessageDetailServiceTest : StringSpec({
             )
         )
 
-        coEvery { ebmsMessageDetailRepository.findByTimeInterval(from, to) } returns listOf(testDetails)
+        coEvery { ebmsMessageDetailRepository.findByTimeInterval(from, to, any()) } returns listOf(testDetails)
         coEvery { ebmsMessageDetailRepository.findRelatedMottakIds(listOf(testDetails.requestId)) } returns
             mapOf(testDetails.requestId to testDetails.calculateMottakId())
         coEvery { eventRepository.findEventsByRequestIds(listOf(testDetails.requestId)) } returns relatedEvents
@@ -163,7 +163,7 @@ class EbmsMessageDetailServiceTest : StringSpec({
             )
         )
 
-        coEvery { ebmsMessageDetailRepository.findByTimeInterval(from, to) } returns listOf(testDetails)
+        coEvery { ebmsMessageDetailRepository.findByTimeInterval(from, to, any()) } returns listOf(testDetails)
         coEvery { ebmsMessageDetailRepository.findRelatedMottakIds(listOf(testDetails.requestId)) } returns
             mapOf(testDetails.requestId to testDetails.calculateMottakId())
         coEvery { eventRepository.findEventsByRequestIds(listOf(testDetails.requestId)) } returns relatedEvents
@@ -182,7 +182,7 @@ class EbmsMessageDetailServiceTest : StringSpec({
         val testDetails2 = buildTestEbmsMessageDetail().copy(conversationId = commonReferenceId)
         val testDetails3 = buildTestEbmsMessageDetail().copy(conversationId = "differentRef456")
 
-        coEvery { ebmsMessageDetailRepository.findByTimeInterval(from, to) } returns listOf(testDetails1, testDetails2, testDetails3)
+        coEvery { ebmsMessageDetailRepository.findByTimeInterval(from, to, any()) } returns listOf(testDetails1, testDetails2, testDetails3)
         coEvery {
             ebmsMessageDetailRepository.findRelatedMottakIds(
                 listOf(testDetails1.requestId, testDetails2.requestId, testDetails3.requestId)

--- a/src/test/kotlin/no/nav/emottak/eventmanager/service/EventServiceTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/service/EventServiceTest.kt
@@ -38,7 +38,7 @@ class EventServiceTest : StringSpec({
         val from = Instant.now()
         val to = from.plusSeconds(60)
 
-        coEvery { eventRepository.findEventByTimeInterval(from, to) } returns listOf(testEvent)
+        coEvery { eventRepository.findEventByTimeInterval(from, to, any()) } returns listOf(testEvent)
         coEvery { ebmsMessageDetailRepository.findByRequestIds(testRequestIds) } returns mapOf()
 
         val eventsList = eventService.fetchEvents(from, to)
@@ -47,7 +47,7 @@ class EventServiceTest : StringSpec({
         eventsList[0].hendelsedeskr shouldBe testEvent.eventType.description
         eventsList[0].tillegsinfo shouldBe testEvent.eventData
 
-        coVerify { eventRepository.findEventByTimeInterval(from, to) }
+        coVerify { eventRepository.findEventByTimeInterval(from, to, 1000) }
         coVerify { ebmsMessageDetailRepository.findByRequestIds(testRequestIds) }
     }
 


### PR DESCRIPTION
1. Begrenset antall resultater for tidsrom søk med 1000. Det var hovedfaktoren som førte til tidsavbruddsfeil.
2. Lagt til index for `ebms_message_details.conversation_id` kolonne
3. Ga mer resurser til tjenesten i `prod-miljø`. 

Oppgave: https://github.com/navikt/team-emottak-docs/issues/246