### PR TITLE
La til auth-krav på endepunkter, endret og utvidet enhetstester

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/route/EventManagerRoutes.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/route/EventManagerRoutes.kt
@@ -1,5 +1,7 @@
 package no.nav.emottak.eventmanager.route
 
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.RoutingCall
@@ -25,24 +27,27 @@ import org.slf4j.LoggerFactory
 private val log = LoggerFactory.getLogger("no.nav.emottak.eventmanager.route.EventManagerRoutes")
 
 fun Routing.eventManagerRoutes(eventService: EventService, ebmsMessageDetailService: EbmsMessageDetailService) {
+    get("/filter-values") {
+        val filterValues = ebmsMessageDetailService.getDistinctRolesServicesActions()
+        if (filterValues == null) {
+            val errorMessage = "Failed to retrieve distinct filter-values for Role, Service and Action!"
+            log.error(errorMessage)
+            call.respond(HttpStatusCode.InternalServerError, errorMessage)
+            return@get
+        }
+        log.debug("Got filter-values (last refreshed at: {})", filterValues.refreshedAt)
+        call.respond(filterValues)
+    }
+
     authenticate(AZURE_AD_AUTH) {
         get("/events") {
             if (!Validation.validateDateRangeRequest(call)) return@get
 
-        val fromDate = Validation.parseDate(call.request.queryParameters[FROM_DATE]!!)
-        val toDate = Validation.parseDate(call.request.queryParameters[TO_DATE]!!)
-        val role = call.request.queryParameters[ROLE] ?: ""
-        val service = call.request.queryParameters[SERVICE] ?: ""
-        val action = call.request.queryParameters[ACTION] ?: ""
+            val fromDate = Validation.parseDate(call.request.queryParameters[FROM_DATE]!!)
+            val toDate = Validation.parseDate(call.request.queryParameters[TO_DATE]!!)
 
-        val pageable = Validation.getPageable(
-            call,
-            call.request.queryParameters[PAGE_NUMBER],
-            call.request.queryParameters[PAGE_SIZE],
-            call.request.queryParameters[SORT],
-            50
-        )
-        if (pageable == null) return@get
+            val (role, service, action) = getRoleServiceActionParameters(call)
+            val pageable = getPagableParameters(call) ?: return@get
 
             log.debug("Retrieving events from database, page ${pageable.pageNumber} with size ${pageable.pageSize} and sort order ${pageable.sort}")
             val eventsPage = eventService.fetchEvents(fromDate, toDate, role, service, action, pageable)
@@ -72,14 +77,14 @@ fun Routing.eventManagerRoutes(eventService: EventService, ebmsMessageDetailServ
         get("/message-details") {
             if (!Validation.validateDateRangeRequest(call)) return@get
 
-        val fromDate = Validation.parseDate(call.request.queryParameters[FROM_DATE]!!)
-        val toDate = Validation.parseDate(call.request.queryParameters[TO_DATE]!!)
-        val readableId = call.request.queryParameters[READABLE_ID] ?: ""
-        val cpaId = call.request.queryParameters[CPA_ID] ?: ""
-        val messageId = call.request.queryParameters[MESSAGE_ID] ?: ""
+            val fromDate = Validation.parseDate(call.request.queryParameters[FROM_DATE]!!)
+            val toDate = Validation.parseDate(call.request.queryParameters[TO_DATE]!!)
+            val readableId = call.request.queryParameters[READABLE_ID] ?: ""
+            val cpaId = call.request.queryParameters[CPA_ID] ?: ""
+            val messageId = call.request.queryParameters[MESSAGE_ID] ?: ""
 
-        val (role, service, action) = getRoleServiceActionParameters(call)
-        val pageable = getPagableParameters(call) ?: return@get
+            val (role, service, action) = getRoleServiceActionParameters(call)
+            val pageable = getPagableParameters(call) ?: return@get
 
             log.debug("Retrieving message details from database, page ${pageable.pageNumber} with size ${pageable.pageSize} and sort order ${pageable.sort}")
             val messageDetailsPage = ebmsMessageDetailService.fetchEbmsMessageDetails(

--- a/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/repository/EbmsMessageDetailRepositoryTest.kt
@@ -87,8 +87,8 @@ class EbmsMessageDetailRepositoryTest : RepositoryTestBase({
     }
 
     "Should retrieve records by time interval and filtered by readableId" {
-        val (messageDetailsInInterval1, _, _, _) = buildAndInsertTestEbmsMessageDetailFindData(repository)
-        val retrievedDetails = repository.findByTimeInterval(
+        val (messageDetailsInInterval1, _, _, _) = buildAndInsertTestEbmsMessageDetailFindData(ebmsMessageDetailRepository)
+        val retrievedDetails = ebmsMessageDetailRepository.findByTimeInterval(
             Instant.parse("2025-04-30T12:00:00Z"),
             Instant.parse("2025-04-30T13:00:00Z"),
             readableIdPattern = messageDetailsInInterval1.generateReadableId()
@@ -157,8 +157,8 @@ class EbmsMessageDetailRepositoryTest : RepositoryTestBase({
     }
 
     "Should retrieve records by time interval and filtered by readableId, cpaId and messageId" {
-        val (_, _, _, messageDetailsOutOfInterval2) = buildAndInsertTestEbmsMessageDetailFindData(repository)
-        val retrievedDetails = repository.findByTimeInterval(
+        val (_, _, _, messageDetailsOutOfInterval2) = buildAndInsertTestEbmsMessageDetailFindData(ebmsMessageDetailRepository)
+        val retrievedDetails = ebmsMessageDetailRepository.findByTimeInterval(
             Instant.parse("2025-04-30T12:00:00Z"),
             Instant.parse("2025-04-30T13:00:00Z"),
             readableIdPattern = messageDetailsOutOfInterval2.generateReadableId(),


### PR DESCRIPTION
Tilhører følgende oppgave: https://github.com/navikt/team-emottak-docs/issues/201

**Edit: Utfordring oppdaget ifm implementering av Azure AD:**
Vi må benytte egne testkontoer (_trygdeetaten.no_ fremfor _nav.no_) og konfigurere disse for tilgang til `emottak-monitor` og `emottak-event-manager` for å kunne teste i dev. Dermed betyr det også at ingen kan bruke sin personlige (vanlige nav-konto) for tilgang til monitoren i dev.

Det må avklares om denne fortsatt skal implementeres, eventuelt om det finnes en omvei som muliggjør fortsatt bruk av personlig nav-konto.