### PR TITLE
Reduserer retentionHours for kafka topics i prod

### DIFF
--- a/.nais/kafka/kafka-prod.yaml
+++ b/.nais/kafka/kafka-prod.yaml
@@ -14,7 +14,7 @@ spec:
     partitions: 1
     replication: 3
     retentionBytes: -1
-    retentionHours: 4380
+    retentionHours: 672
     segmentHours: 168
   acl:
     - access: write
@@ -57,7 +57,7 @@ spec:
     partitions: 1
     replication: 3
     retentionBytes: -1
-    retentionHours: 4380
+    retentionHours: 672
     segmentHours: 168
   acl:
     - access: write


### PR DESCRIPTION
https://github.com/navikt/team-emottak-docs/issues/346

Reduserer `retentionHours` fra 6 måneder til 4 uker for å redusere datamengden. Disse persisteres uansett til database med en gang de leses, så den eneste grunnen til å ha en periode er i tilfelle katastrofisk nedetid på denne tjenesten. 