### PR TITLE
Laget prosedyre som sletter foreldreløse events

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EventService.kt
@@ -148,8 +148,14 @@ class EventService(
     private suspend fun updateConversationStatus(event: Event) {
         val eventStatus = event.getEventStatusChangeEnum()
         if (eventStatus != null) {
-            val conversationId =
-                event.conversationId ?: ebmsMessageDetailRepository.findByRequestId(event.requestId)!!.conversationId
+            val conversationId = event.conversationId ?: ebmsMessageDetailRepository.findByRequestId(event.requestId)?.conversationId
+            if (conversationId == null) {
+                log.warn(
+                    event.marker,
+                    "Cannot update conversation status! EbmsMessageDetail for requestId: ${event.requestId} not found"
+                )
+                return
+            }
             val success = conversationStatusRepository.update(
                 id = conversationId,
                 status = eventStatus

--- a/src/main/resources/db/migration/R__delete_events.sql
+++ b/src/main/resources/db/migration/R__delete_events.sql
@@ -18,6 +18,6 @@ BEGIN
     END IF;
 
     IF NOT EXISTS (SELECT 1 FROM job_status WHERE job_name = v_job_name_events_cleanup) THEN
-        CALL events_cleanup(2, v_job_name_events_cleanup, 10000);
+        CALL events_cleanup(2, v_job_name_events_cleanup, 100000);
     END IF;
 END $$;

--- a/src/main/resources/db/migration/R__delete_events.sql
+++ b/src/main/resources/db/migration/R__delete_events.sql
@@ -1,2 +1,23 @@
-CALL delete_service_events('HarBorgerEgenandelFritak', 10000);
-CALL delete_service_events('HarBorgerFrikort', 10000);
+DO $$
+DECLARE
+    /*  Oppgavebeskrivelse er primærnøkkel som vil sørge for at påbegynt migreringsbatchjobb
+        ikke kjøres på nytt ved redeploy, med mindre beskrivelsen endres.
+        NB: Nais-redeploy vil trolig skje når en jobb tar for lang tid.
+        Dermed vil neste jobb risikere å kjøre i parallell med den forrige, så det må man være klar over at kan skje.
+    */
+    v_job_name_HarBorgerEgenandelFritak text := 'delete_service_events(HarBorgerEgenandelFritak) 1';
+    v_job_name_HarBorgerFrikort text := 'delete_service_events(HarBorgerFrikort) 1';
+    v_job_name_events_cleanup text := 'events_cleanup 1';
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM job_status WHERE job_name = v_job_name_HarBorgerEgenandelFritak) THEN
+        CALL delete_service_events('HarBorgerEgenandelFritak', v_job_name_HarBorgerEgenandelFritak, 10000);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM job_status WHERE job_name = v_job_name_HarBorgerFrikort) THEN
+        CALL delete_service_events('HarBorgerFrikort', v_job_name_HarBorgerFrikort, 10000);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM job_status WHERE job_name = v_job_name_events_cleanup) THEN
+        CALL events_cleanup(2, v_job_name_events_cleanup, 10000);
+    END IF;
+END $$;

--- a/src/main/resources/db/migration/V19__create_job_status_table.sql
+++ b/src/main/resources/db/migration/V19__create_job_status_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS "job_status" (
+    "job_name" VARCHAR(256) PRIMARY KEY,
+    "started_at" TIMESTAMP DEFAULT NOW() NOT NULL,
+    "updated_at" TIMESTAMP,
+    "completed_at" TIMESTAMP,
+    "result_text" VARCHAR(256)
+);
+
+CREATE INDEX IF NOT EXISTS "job_status_job_name_idx" ON "job_status" ("job_name");

--- a/src/main/resources/db/migration/V20__redefine_delete_service_events_procedure.sql
+++ b/src/main/resources/db/migration/V20__redefine_delete_service_events_procedure.sql
@@ -1,0 +1,95 @@
+CREATE OR REPLACE PROCEDURE delete_service_events(
+    p_service text,
+    p_job_name text,
+    p_batch_size int DEFAULT 10000
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_deleted_count int;
+    v_total_deleted_events BIGINT := 0;
+    v_total_deleted_conversations BIGINT := 0;
+    v_total_deleted_message_details BIGINT := 0;
+    v_request_ids UUID[];
+    v_conversation_ids text[];
+    v_conversation_status_table_exists BOOLEAN;
+    v_result_text text;
+BEGIN
+    INSERT INTO job_status (job_name) VALUES (p_job_name);
+    COMMIT;
+
+    -- Hopp over sletting hvis ebms_message_details ikke lenger inneholder service som skal slettes:
+    IF NOT EXISTS (SELECT 1 FROM ebms_message_details WHERE service = p_service LIMIT 1) THEN
+        v_result_text := FORMAT('No rows found for service %s, skipping deletion', p_service);
+        UPDATE job_status
+        SET completed_at = NOW(), updated_at = NOW(), result_text = v_result_text
+        WHERE job_name = p_job_name;
+        RAISE NOTICE 'DELETING %: %', p_service, v_result_text;
+        COMMIT;
+        RETURN;
+    END IF;
+
+    -- Sjekk om conversation_status-tabellen eksisterer:
+    v_conversation_status_table_exists := to_regclass('public.conversation_status') IS NOT NULL;
+
+    LOOP
+        -- Hent relevante request_id'er og conversation_id'er som skal slettes:
+        SELECT ARRAY_AGG(request_id), ARRAY_AGG(conversation_id)
+        INTO v_request_ids, v_conversation_ids
+        FROM (
+             SELECT request_id, conversation_id
+             FROM ebms_message_details
+             WHERE service = p_service
+             LIMIT p_batch_size
+         ) sub;
+
+        -- Avslutt loop hvis ingen flere rader igjen:
+        IF v_request_ids IS NULL OR array_length(v_request_ids, 1) IS NULL THEN
+            EXIT;
+        END IF;
+
+        -- Slett hendelser:
+        DELETE FROM events
+        WHERE request_id = ANY(v_request_ids);
+
+        GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+        v_total_deleted_events := v_total_deleted_events + v_deleted_count;
+
+        -- Slett conversations:
+        IF v_conversation_status_table_exists THEN
+            DELETE FROM conversation_status
+            WHERE conversation_id = ANY(v_conversation_ids);
+
+            GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+            v_total_deleted_conversations := v_total_deleted_conversations + v_deleted_count;
+        END IF;
+
+        -- Og til slutt slett meldingsdetaljer:
+        DELETE FROM ebms_message_details
+        WHERE request_id = ANY(v_request_ids);
+
+        GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+        v_total_deleted_message_details := v_total_deleted_message_details + v_deleted_count;
+
+        v_result_text := FORMAT('Deleted %s rows from ebms_message_details, %s rows from events, and %s rows from conversation_status',
+                     p_service, v_total_deleted_message_details, v_total_deleted_events, v_total_deleted_conversations);
+
+        UPDATE job_status
+        SET updated_at = NOW(), result_text = v_result_text
+        WHERE job_name = p_job_name;
+
+        COMMIT;
+        PERFORM pg_sleep(0.01); -- Small pause to reduce lock contention
+    END LOOP;
+
+    v_result_text := FORMAT('Deleted %s rows from ebms_message_details, %s rows from events, and %s rows from conversation_status',
+                 p_service, v_total_deleted_message_details, v_total_deleted_events, v_total_deleted_conversations);
+
+    UPDATE job_status
+    SET completed_at = NOW(), result_text = v_result_text
+    WHERE job_name = p_job_name;
+
+    RAISE NOTICE 'DELETING %: %', p_service, v_result_text;
+    COMMIT;
+END;
+$$;

--- a/src/main/resources/db/migration/V20__redefine_delete_service_events_procedure.sql
+++ b/src/main/resources/db/migration/V20__redefine_delete_service_events_procedure.sql
@@ -83,7 +83,7 @@ BEGIN
     END LOOP;
 
     v_result_text := FORMAT('Deleted %s rows from ebms_message_details, %s rows from events, and %s rows from conversation_status',
-                 p_service, v_total_deleted_message_details, v_total_deleted_events, v_total_deleted_conversations);
+                 v_total_deleted_message_details, v_total_deleted_events, v_total_deleted_conversations);
 
     UPDATE job_status
     SET completed_at = NOW(), result_text = v_result_text

--- a/src/main/resources/db/migration/V20__redefine_delete_service_events_procedure.sql
+++ b/src/main/resources/db/migration/V20__redefine_delete_service_events_procedure.sql
@@ -40,6 +40,7 @@ BEGIN
              SELECT request_id, conversation_id
              FROM ebms_message_details
              WHERE service = p_service
+             ORDER BY saved_at
              LIMIT p_batch_size
          ) sub;
 

--- a/src/main/resources/db/migration/V21__define_events_cleanup.sql
+++ b/src/main/resources/db/migration/V21__define_events_cleanup.sql
@@ -27,7 +27,7 @@ BEGIN
             SELECT e.event_id
             FROM events e
             WHERE e.created_at < v_hours_ago
-            AND e.request_id <> ALL(v_request_ids) -- <> er det samme som NOT IN, men er explisitt designet for arrays.
+            AND e.request_id <> ALL(v_request_ids) -- <> er det samme som NOT IN, men er eksplisitt designet for arrays.
             LIMIT p_batch_size
         )
         DELETE FROM events WHERE event_id IN (SELECT event_id FROM to_delete);

--- a/src/main/resources/db/migration/V21__define_events_cleanup.sql
+++ b/src/main/resources/db/migration/V21__define_events_cleanup.sql
@@ -1,0 +1,52 @@
+CREATE OR REPLACE PROCEDURE events_cleanup(
+    p_hours int,                    -- Angir hvor mange timer en event må være "foreldreløs" for at event'en kan slettes.
+                                    -- 2 betyr "foreldreløse events opprettet for mer enn 2 timer siden slettes".
+    p_job_name text,                -- Navn på batch-jobben, for å ha et unikt innslag i job_status-tabellen
+    p_batch_size int DEFAULT 100000 -- Hvor mange events som skal slettes om gangen.
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_request_ids UUID[];
+    v_hours_ago TIMESTAMP := NOW() - (p_hours || ' hours')::INTERVAL;
+    v_deleted_count int;
+    v_deleted_count_total BIGINT := 0;
+    v_result_text text;
+BEGIN
+    INSERT INTO job_status (job_name) VALUES (p_job_name);
+    COMMIT;
+
+    SELECT ARRAY_AGG(request_id) INTO v_request_ids FROM ebms_message_details;
+    v_result_text := FORMAT('Loaded %s request ids into memory', array_length(v_request_ids, 1));
+    UPDATE job_status SET updated_at = NOW(), result_text = v_result_text WHERE job_name = p_job_name;
+    RAISE NOTICE 'EVENTS CLEANUP: %', v_result_text;
+    COMMIT;
+
+    LOOP
+        WITH to_delete AS (
+            SELECT e.event_id
+            FROM events e
+            WHERE e.created_at < v_hours_ago
+            AND e.request_id <> ALL(v_request_ids) -- <> er det samme som NOT IN, men er explisitt designet for arrays.
+            LIMIT p_batch_size
+        )
+        DELETE FROM events WHERE event_id IN (SELECT event_id FROM to_delete);
+
+        GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+        IF v_deleted_count = 0 THEN
+            EXIT;
+        END IF;
+
+        v_deleted_count_total := v_deleted_count_total + v_deleted_count;
+        v_result_text := FORMAT('%s events deleted', v_deleted_count_total);
+        UPDATE job_status SET updated_at = NOW(), result_text = v_result_text WHERE job_name = p_job_name;
+        RAISE NOTICE 'EVENTS CLEANUP: %', v_result_text;
+
+        COMMIT;
+    END LOOP;
+
+    UPDATE job_status SET completed_at = NOW() WHERE job_name = p_job_name;
+    RAISE NOTICE 'EVENTS CLEANUP: Complete';
+    COMMIT;
+END;
+$$;

--- a/src/test/kotlin/no/nav/emottak/eventmanager/service/EventServiceTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/service/EventServiceTest.kt
@@ -169,6 +169,26 @@ class EventServiceTest : StringSpec({
         coVerify { eventRepository.insert(testEvent) }
         coVerify(exactly = 1) { ebmsMessageDetailRepository.findByRequestId(testEvent.requestId) }
         coVerify(exactly = 1) { conversationStatusRepository.update(testMessageDetail.conversationId, EventStatusEnum.PROCESSING_COMPLETED, any()) }
+        coVerify(exactly = 1) { eventRepository.insert(testEvent) }
+    }
+
+    "Should continue inserting event even if ebmsMessageDetailRepository.findByRequestId does not find the corresponding message detail" {
+        val testTransportEvent = buildTestTransportEvent().copy(
+            eventType = EventType.MESSAGEFLOW_COMPLETED,
+            conversationId = null
+        )
+        val testEvent = Event.fromTransportModel(testTransportEvent)
+
+        coEvery { eventRepository.insert(testEvent) } returns testEvent.requestId
+        coEvery { ebmsMessageDetailRepository.findByRequestId(testEvent.requestId) } returns null
+        coEvery { conversationStatusRepository.update(any(), EventStatusEnum.PROCESSING_COMPLETED, any()) } returns true
+
+        eventService.process(testTransportEvent.toByteArray())
+
+        coVerify { eventRepository.insert(testEvent) }
+        coVerify(exactly = 1) { ebmsMessageDetailRepository.findByRequestId(testEvent.requestId) }
+        coVerify(exactly = 0) { conversationStatusRepository.update(any(), EventStatusEnum.PROCESSING_COMPLETED, any()) }
+        coVerify(exactly = 1) { eventRepository.insert(testEvent) }
     }
 
     "Should not update conversation status on event types of status INFORMATION" {


### PR DESCRIPTION
Laget først en `job_status`-tabell som holder rede på batch-jobber som kjøres. På den måten sørger vi for at en NAIS-redeploy ikke gjør at samme jobben starter på nytt.

Laget deretter en prosedyre som sletter foreldreløse events (events hvor `request_id` ikke finnes i `ebms_message_details`-tabellen).

https://github.com/navikt/team-emottak-docs/issues/342