### PR TITLE
Bugfix: Sett timeout til 0 (uendelig) for prosedyrekall

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
@@ -137,8 +137,8 @@ suspend fun runSequentialDelayedTasks(
             log.info("Launching task: '$jobName'")
             try {
                 when (val args = procedure.args) {
-                    is ProcedureArgs.DeleteServiceArgs -> jobStatusRepository.callDeleteServiceEventsProcedure(args.service, jobName)
-                    is ProcedureArgs.CleanupArgs -> jobStatusRepository.callEventsCleanupProcedure(args.hours, jobName)
+                    is ProcedureArgs.DeleteServiceArgs -> jobStatusRepository.callDeleteServiceEventsProcedure(jobName, args)
+                    is ProcedureArgs.CleanupArgs -> jobStatusRepository.callEventsCleanupProcedure(jobName, args)
                 }
                 log.info("Task completed: '$jobName'")
             } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/model/ProcedureArgs.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/model/ProcedureArgs.kt
@@ -1,6 +1,6 @@
 package no.nav.emottak.eventmanager.model
 
 sealed class ProcedureArgs {
-    data class DeleteServiceArgs(val service: String) : ProcedureArgs()
-    data class CleanupArgs(val hours: Int) : ProcedureArgs()
+    data class DeleteServiceArgs(val service: String, val batchSize: Int = 10000) : ProcedureArgs()
+    data class CleanupArgs(val hours: Int, val batchSize: Int = 10000) : ProcedureArgs()
 }

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/Database.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/Database.kt
@@ -28,8 +28,6 @@ class Database(
             .load()
         log.info("Flyway: configuration loaded, starting repair() then migrate()")
         try {
-            flyway.repair() // Kan slettes etter at deploy til PROD er utført
-            log.info("Flyway: repair() completed")
             flyway.migrate()
             log.info("Flyway: migrate() completed successfully")
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/JobStatusRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/JobStatusRepository.kt
@@ -1,7 +1,9 @@
 package no.nav.emottak.eventmanager.persistence.repository
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.withContext
+import no.nav.emottak.eventmanager.model.ProcedureArgs
 import no.nav.emottak.eventmanager.persistence.Database
 import no.nav.emottak.eventmanager.persistence.table.JobStatusTable
 import org.jetbrains.exposed.sql.selectAll
@@ -18,26 +20,30 @@ class JobStatusRepository(private val database: Database) {
     // These procedures use explicit COMMIT statements for batch processing, so they must be
     // called outside any client-managed transaction (autoCommit=true). Wrapping in transaction {}
     // would cause PostgreSQL to throw "invalid transaction termination" on the internal COMMITs.
+    // networkTimeout is set to 0 (unlimited) because these procedures can run for a long time on
+    // large datasets — the default socketTimeout=30s in the JDBC URL would otherwise kill them.
 
-    suspend fun callDeleteServiceEventsProcedure(service: String, jobName: String) = withContext(Dispatchers.IO) {
+    suspend fun callDeleteServiceEventsProcedure(jobName: String, args: ProcedureArgs.DeleteServiceArgs) = withContext(Dispatchers.IO) {
         database.dataSource.connection.use { connection ->
             connection.autoCommit = true
+            connection.setNetworkTimeout(Dispatchers.IO.asExecutor(), 0)
             connection.prepareCall("CALL delete_service_events(?, ?, ?)").use { stmt ->
-                stmt.setString(1, service)
+                stmt.setString(1, args.service)
                 stmt.setString(2, jobName)
-                stmt.setInt(3, 10000)
+                stmt.setInt(3, args.batchSize)
                 stmt.execute()
             }
         }
     }
 
-    suspend fun callEventsCleanupProcedure(hours: Int, jobName: String) = withContext(Dispatchers.IO) {
+    suspend fun callEventsCleanupProcedure(jobName: String, args: ProcedureArgs.CleanupArgs) = withContext(Dispatchers.IO) {
         database.dataSource.connection.use { connection ->
             connection.autoCommit = true
+            connection.setNetworkTimeout(Dispatchers.IO.asExecutor(), 0)
             connection.prepareCall("CALL events_cleanup(?, ?, ?)").use { stmt ->
-                stmt.setInt(1, hours)
+                stmt.setInt(1, args.hours)
                 stmt.setString(2, jobName)
-                stmt.setInt(3, 100000)
+                stmt.setInt(3, args.batchSize)
                 stmt.execute()
             }
         }


### PR DESCRIPTION
**Bakgrunn:**
I forbinnelse med [opprydding av foreldreløse events](https://github.com/navikt/team-emottak-docs/issues/342) ble kjøring av prosedyrene flyttet fra repeatable migration til en forsinket oppgavekjøring i `App.kt` (PR: https://github.com/navikt/emottak-event-manager/pull/68).

Dette kjørte fint i `DEV`, men i `PROD` får `events_cleanup` timeout etter 30 sekunder:
```
org.postgresql.util.PSQLException: An I/O error occurred while sending to the backend.
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:398)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:502)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:419)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:194)
	at org.postgresql.jdbc.PgCallableStatement.executeWithFlags(PgCallableStatement.java:90)
	at org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:180)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.execute(ProxyPreparedStatement.java:44)
	at com.zaxxer.hikari.pool.HikariProxyCallableStatement.execute(HikariProxyCallableStatement.java)
	at no.nav.emottak.eventmanager.persistence.repository.JobStatusRepository$callEventsCleanupProcedure$2.invokeSuspend(JobStatusRepository.kt:41)
	at [...]
Caused by: java.net.SocketTimeoutException: Read timed out
	at java.base/sun.nio.ch.NioSocketImpl.timedRead(Unknown Source)
	at [...]
```

**Fiks i denne PR:**
- Overstyrt timeout i kallene mot prosedyrene til 0 (uendelig) slik at det ikke feiler etter 30 sek med `SocketTimeoutException`.
- Lagt til `batchSize` som argument i ProcedureArgs-subklassene.
- Satt `batchSize` til 10 000 for `events_cleanup` (default 100 000).
- Tatt vekk `flyway.repair()` ettersom vi har deployet til PROD.