### PR TITLE
Bugfix: Henting av distinct roller, services og actions bruker for lang tid i PROD

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
@@ -66,6 +66,7 @@ suspend fun ResourceScope.runServer() {
     val conversationStatusRepository = ConversationStatusRepository(database)
     val jobStatusRepository = JobStatusRepository(database)
 
+    distinctRolesServicesActionsRepository.initialize()
     val eventService = EventService(eventRepository, ebmsMessageDetailRepository, conversationStatusRepository)
     val ebmsMessageDetailService =
         EbmsMessageDetailService(eventRepository, ebmsMessageDetailRepository, eventTypeRepository, distinctRolesServicesActionsRepository, conversationStatusRepository)

--- a/src/main/kotlin/no/nav/emottak/eventmanager/configuration/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/configuration/Config.kt
@@ -28,8 +28,7 @@ data class Database(
     val vaultJdbcUrl: VaultJdbcUrl,
     val dbCredentialsMountPath: DbCredentialsMountPath,
     val maxConnectionPoolSizeForUser: MaxConnectionPoolSizeForUser,
-    val maxConnectionPoolSizeForAdmin: MaxConnectionPoolSizeForAdmin,
-    val distinctValuesRefreshRateInHours: DistinctValuesRefreshRateInHours
+    val maxConnectionPoolSizeForAdmin: MaxConnectionPoolSizeForAdmin
 )
 
 data class EventConsumer(
@@ -57,9 +56,6 @@ value class MaxConnectionPoolSizeForUser(val value: Int)
 
 @JvmInline
 value class MaxConnectionPoolSizeForAdmin(val value: Int)
-
-@JvmInline
-value class DistinctValuesRefreshRateInHours(val value: Long)
 
 fun Kafka.toProperties() = Properties()
     .apply {

--- a/src/main/kotlin/no/nav/emottak/eventmanager/model/dto/DistinctRolesServicesActionsDto.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/model/dto/DistinctRolesServicesActionsDto.kt
@@ -1,14 +1,10 @@
 package no.nav.emottak.eventmanager.model.dto
 
 import kotlinx.serialization.Serializable
-import no.nav.emottak.utils.serialization.InstantSerializer
-import java.time.Instant
 
 @Serializable
 data class DistinctRolesServicesActionsDto(
     val roles: List<String>,
     val services: List<String>,
-    val actions: List<String>,
-    @Serializable(with = InstantSerializer::class)
-    val refreshedAt: Instant
+    val actions: List<String>
 )

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/DistinctRolesServicesActionsRepository.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/repository/DistinctRolesServicesActionsRepository.kt
@@ -5,109 +5,64 @@ import kotlinx.coroutines.withContext
 import no.nav.emottak.eventmanager.model.dto.DistinctRolesServicesActionsDto
 import no.nav.emottak.eventmanager.persistence.Database
 import no.nav.emottak.eventmanager.persistence.table.DistinctRolesServicesActionsTable
-import no.nav.emottak.eventmanager.persistence.table.EbmsMessageDetailTable
-import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.CustomFunction
-import org.jetbrains.exposed.sql.Expression
-import org.jetbrains.exposed.sql.QueryBuilder
-import org.jetbrains.exposed.sql.TextColumnType
-import org.jetbrains.exposed.sql.alias
-import org.jetbrains.exposed.sql.javatime.CurrentTimestamp
+import org.jetbrains.exposed.sql.insertIgnore
 import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.stringLiteral
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.jetbrains.exposed.sql.upsert
-import kotlin.collections.sorted
 
 class DistinctRolesServicesActionsRepository(private val database: Database) {
 
-    suspend fun getDistinctRolesServicesActions(): DistinctRolesServicesActionsDto? = withContext(Dispatchers.IO) {
-        transaction(database.db) {
-            DistinctRolesServicesActionsTable
-                .selectAll()
-                .singleOrNull()
-                ?.let { row ->
-                    val roles = nullableStringToList(row[DistinctRolesServicesActionsTable.roles])
-                    val services = nullableStringToList(row[DistinctRolesServicesActionsTable.services])
-                    val actions = nullableStringToList(row[DistinctRolesServicesActionsTable.actions])
-                    if (roles == null || services == null || actions == null) {
-                        null
-                    } else {
-                        DistinctRolesServicesActionsDto(
-                            roles = roles.sorted(),
-                            services = services.sorted(),
-                            actions = actions.sorted(),
-                            refreshedAt = row[DistinctRolesServicesActionsTable.refreshedAt]
-                        )
+    @Volatile private var roles: Set<String> = emptySet()
+
+    @Volatile private var services: Set<String> = emptySet()
+
+    @Volatile private var actions: Set<String> = emptySet()
+
+    suspend fun initialize() = loadFromDb()
+
+    fun getAll(): DistinctRolesServicesActionsDto = DistinctRolesServicesActionsDto(
+        roles = roles.sortedWith(String.CASE_INSENSITIVE_ORDER),
+        services = services.sortedWith(String.CASE_INSENSITIVE_ORDER),
+        actions = actions.sortedWith(String.CASE_INSENSITIVE_ORDER)
+    )
+
+    suspend fun addIfAbsent(role: String?, service: String, action: String) = withContext(Dispatchers.IO) {
+        val isNew = (role != null && role !in roles) || service !in services || action !in actions
+        if (isNew) {
+            transaction(database.db) {
+                role?.let { r ->
+                    DistinctRolesServicesActionsTable.insertIgnore {
+                        it[type] = "role"
+                        it[value] = r
                     }
                 }
-        }
-    }
-
-    suspend fun refreshDistinctRolesServicesActions(): DistinctRolesServicesActionsDto = withContext(Dispatchers.IO) {
-        transaction(database.db) {
-            /*
-            SELECT string_agg(distinct from_role::text, ',') AS roles,
-                   string_agg(distinct service::text, ',') AS services,
-                   string_agg(distinct action::text, ',') AS actions,
-                   now() AS refreshed_at
-            FROM (SELECT "from_role", "service", "action" FROM "ebms_message_details") sub;
-             */
-            val rolesAlias = StringAggDistinct(EbmsMessageDetailTable.fromRole).alias("roles")
-            val servicesAlias = StringAggDistinct(EbmsMessageDetailTable.service).alias("services")
-            val actionsAlias = StringAggDistinct(EbmsMessageDetailTable.action).alias("actions")
-            val refreshedAlias = CurrentTimestamp.alias("refreshed_at")
-
-            val distinctValues = EbmsMessageDetailTable
-                .select(
-                    rolesAlias,
-                    servicesAlias,
-                    actionsAlias,
-                    refreshedAlias
-                ).single()
-
-            val roles = distinctValues[rolesAlias]
-            val services = distinctValues[servicesAlias]
-            val actions = distinctValues[actionsAlias]
-            val refreshedAt = distinctValues[refreshedAlias]
-
-            // Insert or update the existing row in the table:
-            DistinctRolesServicesActionsTable.upsert {
-                it[DistinctRolesServicesActionsTable.id] = 1
-                it[DistinctRolesServicesActionsTable.roles] = roles
-                it[DistinctRolesServicesActionsTable.services] = services
-                it[DistinctRolesServicesActionsTable.actions] = actions
-                it[DistinctRolesServicesActionsTable.refreshedAt] = refreshedAt
+                DistinctRolesServicesActionsTable.insertIgnore {
+                    it[type] = "service"
+                    it[value] = service
+                }
+                DistinctRolesServicesActionsTable.insertIgnore {
+                    it[type] = "action"
+                    it[value] = action
+                }
             }
-
-            DistinctRolesServicesActionsDto(
-                roles = roles.split(",").sorted(),
-                services = services.split(",").sorted(),
-                actions = actions.split(",").sorted(),
-                refreshedAt = refreshedAt
-            )
+            loadFromDb()
         }
     }
 
-    private fun nullableStringToList(value: String?, delimeters: String = ",") = value
-        ?.split(delimeters)
-        ?.filter { it.isNotBlank() }
-}
-
-// Wrapper that renders: string_agg(distinct <expr>::text, ',')
-class StringAggDistinct(column: Column<*>) :
-    CustomFunction<String>(
-        functionName = "string_agg",
-        columnType = TextColumnType(),
-        column,
-        stringLiteral(",")
-    ) {
-    private val colExpr: Expression<*> = column
-
-    // Override the rendering so we can inject the `DISTINCT …::text` part.
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        queryBuilder.append("string_agg(distinct ")
-        colExpr.toQueryBuilder(queryBuilder)
-        queryBuilder.append("::text, ',')")
+    private suspend fun loadFromDb() = withContext(Dispatchers.IO) {
+        val newRoles = mutableSetOf<String>()
+        val newServices = mutableSetOf<String>()
+        val newActions = mutableSetOf<String>()
+        transaction(database.db) {
+            DistinctRolesServicesActionsTable.selectAll().forEach { row ->
+                when (row[DistinctRolesServicesActionsTable.type]) {
+                    "role" -> newRoles.add(row[DistinctRolesServicesActionsTable.value])
+                    "service" -> newServices.add(row[DistinctRolesServicesActionsTable.value])
+                    "action" -> newActions.add(row[DistinctRolesServicesActionsTable.value])
+                }
+            }
+        }
+        roles = newRoles
+        services = newServices
+        actions = newActions
     }
 }

--- a/src/main/kotlin/no/nav/emottak/eventmanager/persistence/table/DistinctRolesServicesActionsTable.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/persistence/table/DistinctRolesServicesActionsTable.kt
@@ -2,15 +2,10 @@ package no.nav.emottak.eventmanager.persistence.table
 
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.javatime.timestamp
-import java.time.Instant
 
-object DistinctRolesServicesActionsTable : Table("distict_roles_services_actions") {
-    val id: Column<Int> = integer("id")
-    val roles: Column<String> = text("roles")
-    val services: Column<String> = text("services")
-    val actions: Column<String> = text("actions")
-    val refreshedAt: Column<Instant> = timestamp("refreshed_at")
+object DistinctRolesServicesActionsTable : Table("distinct_roles_services_actions") {
+    val type: Column<String> = varchar("type", 10)
+    val value: Column<String> = text("value")
 
-    override val primaryKey = PrimaryKey(id)
+    override val primaryKey = PrimaryKey(type, value)
 }

--- a/src/main/kotlin/no/nav/emottak/eventmanager/route/EventManagerRoutes.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/route/EventManagerRoutes.kt
@@ -38,7 +38,6 @@ fun Route.eventManagerRoutes(
 ) {
     get("/filter-values") {
         val filterValues = ebmsMessageDetailService.getDistinctRolesServicesActions()
-        log.debug("Got filter-values (last refreshed at: {})", filterValues.refreshedAt)
         call.respond(filterValues)
     }
 

--- a/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailService.kt
@@ -1,7 +1,6 @@
 package no.nav.emottak.eventmanager.service
 
 import kotlinx.serialization.json.Json
-import no.nav.emottak.eventmanager.configuration.config
 import no.nav.emottak.eventmanager.constants.Constants
 import no.nav.emottak.eventmanager.model.EbmsMessageDetail
 import no.nav.emottak.eventmanager.model.Event
@@ -20,14 +19,10 @@ import no.nav.emottak.eventmanager.persistence.table.EventStatusEnum.INFORMATION
 import no.nav.emottak.eventmanager.persistence.table.EventStatusEnum.PROCESSING_COMPLETED
 import no.nav.emottak.eventmanager.route.validation.Validation
 import no.nav.emottak.utils.common.toOsloZone
-import no.nav.emottak.utils.common.zoneOslo
 import no.nav.emottak.utils.kafka.model.EventDataType
 import no.nav.emottak.utils.kafka.model.EventType
-import org.jetbrains.annotations.TestOnly
 import org.slf4j.LoggerFactory
-import java.time.Clock
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
 import no.nav.emottak.utils.kafka.model.EbmsMessageDetail as TransportEbmsMessageDetail
 
@@ -36,8 +31,7 @@ class EbmsMessageDetailService(
     private val ebmsMessageDetailRepository: EbmsMessageDetailRepository,
     private val eventTypeRepository: EventTypeRepository,
     private val distinctRolesServicesActionsRepository: DistinctRolesServicesActionsRepository,
-    private val conversationStatusRepository: ConversationStatusRepository,
-    private var clock: Clock = Clock.system(zoneOslo())
+    private val conversationStatusRepository: ConversationStatusRepository
 ) {
     private val log = LoggerFactory.getLogger(EbmsMessageDetailService::class.java)
 
@@ -49,6 +43,15 @@ class EbmsMessageDetailService(
             val ebmsMessageDetail: EbmsMessageDetail = EbmsMessageDetail.fromTransportModel(transportEbmsMessageDetail)
             ebmsMessageDetailRepository.insert(ebmsMessageDetail)
             log.info(ebmsMessageDetail.marker, "EBMS message details processed successfully: $ebmsMessageDetail")
+            try {
+                distinctRolesServicesActionsRepository.addIfAbsent(
+                    ebmsMessageDetail.fromRole,
+                    ebmsMessageDetail.service,
+                    ebmsMessageDetail.action
+                )
+            } catch (e: Exception) {
+                log.warn("Failed to update distinct roles/services/actions cache", e)
+            }
             if (ebmsMessageDetail.refToMessageId != null) return
             if (conversationStatusRepository.insert(ebmsMessageDetail.conversationId)) {
                 log.info(ebmsMessageDetail.marker, "Conversation status inserted successfully: {}", ebmsMessageDetail.conversationId)
@@ -152,14 +155,8 @@ class EbmsMessageDetailService(
             .isNotEmpty()
     }
 
-    suspend fun getDistinctRolesServicesActions(): DistinctRolesServicesActionsDto {
-        val filterValues = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-        val refreshRate = Instant.now(clock).minus(config().database.distinctValuesRefreshRateInHours.value, ChronoUnit.HOURS)
-        if (filterValues == null || refreshRate.isAfter(filterValues.refreshedAt)) {
-            log.info("Requesting refresh of distict_roles_services_actions")
-            return distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions()
-        }
-        return filterValues
+    fun getDistinctRolesServicesActions(): DistinctRolesServicesActionsDto {
+        return distinctRolesServicesActionsRepository.getAll()
     }
 
     private fun findSenderName(requestId: Uuid, events: List<Event>): String {
@@ -242,10 +239,5 @@ class EbmsMessageDetailService(
             filters.add("pageNumber:'${pageable.pageNumber}'")
         }
         return filters.joinToString(", ")
-    }
-
-    @TestOnly
-    fun setClockForTests(testClock: Clock) {
-        clock = testClock
     }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,7 +8,6 @@ database {
   dbCredentialsMountPath = "${DB_CREDENTIALS_MOUNT_PATH:-}"
   maxConnectionPoolSizeForUser = "4"
   maxConnectionPoolSizeForAdmin = "1"
-  distinctValuesRefreshRateInHours = "24"
 }
 
 environment {

--- a/src/main/resources/db/migration/V25__migrate_distinct_roles_services_actions.sql
+++ b/src/main/resources/db/migration/V25__migrate_distinct_roles_services_actions.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "distinct_roles_services_actions" (
+    "type" VARCHAR(10) NOT NULL,
+    "value" TEXT NOT NULL,
+    PRIMARY KEY ("type", "value")
+);
+
+-- Migrate data from the old distict_roles_services_actions table:
+INSERT INTO "distinct_roles_services_actions" ("type", "value")
+SELECT DISTINCT 'role', unnest(string_to_array(roles, ','))
+FROM "distict_roles_services_actions"
+WHERE roles IS NOT NULL AND roles != ''
+UNION
+SELECT DISTINCT 'service', unnest(string_to_array(services, ','))
+FROM "distict_roles_services_actions"
+WHERE services IS NOT NULL AND services != ''
+UNION
+SELECT DISTINCT 'action', unnest(string_to_array(actions, ','))
+FROM "distict_roles_services_actions"
+WHERE actions IS NOT NULL AND actions != ''
+ON CONFLICT DO NOTHING;
+
+-- Delete the old distict_roles_services_actions table (typo in distinct):
+DROP TABLE "distict_roles_services_actions";

--- a/src/test/kotlin/no/nav/emottak/eventmanager/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/ApplicationTest.kt
@@ -66,12 +66,9 @@ import no.nav.emottak.eventmanager.service.EventService
 import no.nav.emottak.utils.common.model.DuplicateCheckRequest
 import no.nav.emottak.utils.common.model.DuplicateCheckResponse
 import no.nav.emottak.utils.common.toOsloZone
-import no.nav.emottak.utils.common.zoneOslo
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.testcontainers.containers.PostgreSQLContainer
-import java.time.Clock
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import kotlin.uuid.Uuid
 
 class ApplicationTest : StringSpec({
@@ -157,8 +154,10 @@ class ApplicationTest : StringSpec({
         db.dataSource.connection.use { conn ->
             conn.createStatement().execute("DELETE FROM events")
             conn.createStatement().execute("DELETE FROM ebms_message_details")
+            conn.createStatement().execute("DELETE FROM distinct_roles_services_actions")
             conn.createStatement().execute("DELETE FROM conversation_status")
         }
+        distinctRolesServicesActionsRepository.initialize()
     }
 
     "Root endpoint should return OK" {
@@ -800,7 +799,7 @@ class ApplicationTest : StringSpec({
 
     "filter-values endpoint should return list of distinct roles, services and actions" {
         withTestApplication { httpClient ->
-            buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository)
+            buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository, distinctRolesServicesActionsRepository)
 
             val httpResponse = httpClient.getWithAuth("/filter-values", getToken)
             httpResponse.status shouldBe HttpStatusCode.OK
@@ -811,9 +810,9 @@ class ApplicationTest : StringSpec({
         }
     }
 
-    "filter-values endpoint should retrieve refreshed filters and handle filter-values as-is (case-sensitive)" {
+    "filter-values endpoint should reflect new values immediately and preserve case" {
         withTestApplication { httpClient ->
-            buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository)
+            buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository, distinctRolesServicesActionsRepository)
 
             var httpResponse = httpClient.getWithAuth("/filter-values", getToken)
             httpResponse.status shouldBe HttpStatusCode.OK
@@ -822,24 +821,14 @@ class ApplicationTest : StringSpec({
             filters.services.size shouldBe 2
             filters.actions.size shouldBe 2
 
-            ebmsMessageDetailRepository.insert(buildTestEbmsMessageDetail().copy(fromRole = "different-ROLE", action = "new1"))
+            // New distinct values added via addIfAbsent are reflected immediately (no delay needed)
+            distinctRolesServicesActionsRepository.addIfAbsent("different-ROLE", "test-service", "new-action")
 
             httpResponse = httpClient.getWithAuth("/filter-values", getToken)
             httpResponse.status shouldBe HttpStatusCode.OK
             filters = httpResponse.body()
-            filters.roles.size shouldBe 2 // Still 2 since its less than 24h since we refreshed last time
-            filters.actions.size shouldBe 2
-
-            ebmsMessageDetailRepository.insert(buildTestEbmsMessageDetail().copy(action = "new2"))
-            val tomorrow = Clock.fixed(Instant.now().plus(24, ChronoUnit.HOURS), zoneOslo())
-            ebmsMessageDetailService.setClockForTests(tomorrow)
-
-            httpResponse = httpClient.getWithAuth("/filter-values", getToken)
-            httpResponse.status shouldBe HttpStatusCode.OK
-            filters = httpResponse.body()
-            filters.roles.size shouldBe 3 // Now it should be 3
-            filters.services.size shouldBe 2
-            filters.actions.size shouldBe 4 // new1 and new2 are also added
+            filters.roles.size shouldBe 3
+            filters.actions.size shouldBe 3
 
             filters.roles shouldContain "different-role"
             filters.roles shouldContain "different-ROLE"
@@ -848,8 +837,6 @@ class ApplicationTest : StringSpec({
 
     "filter-values endpoint should return Unauthorized if access token is missing" {
         withTestApplication { httpClient ->
-            buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository)
-
             val httpResponse = httpClient.get("/filter-values")
             httpResponse.status shouldBe HttpStatusCode.Unauthorized
         }

--- a/src/test/kotlin/no/nav/emottak/eventmanager/repository/DistinctRolesServicesActionsRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/repository/DistinctRolesServicesActionsRepositoryTest.kt
@@ -3,25 +3,36 @@ package no.nav.emottak.eventmanager.repository
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 
 class DistinctRolesServicesActionsRepositoryTest : RepositoryTestBase({
 
-    "Should retrieve null when calling getDistinctRolesServicesActions() for the first time" {
-        buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository)
-        var result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-        result shouldBe null
+    "Should return empty lists when no values have been added" {
+        distinctRolesServicesActionsRepository.initialize()
+        val result = distinctRolesServicesActionsRepository.getAll()
+        result.roles shouldBe emptyList()
+        result.services shouldBe emptyList()
+        result.actions shouldBe emptyList()
     }
 
-    "Should retrieve filter-values" {
-        buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository)
-        var result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-        result shouldBe null
-        distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions()
-        result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
+    "Should return values after addIfAbsent" {
+        distinctRolesServicesActionsRepository.addIfAbsent("test-role", "test-service", "test-action")
+        val result = distinctRolesServicesActionsRepository.getAll()
+        result.roles.size shouldBe 1
+        result.services.size shouldBe 1
+        result.actions.size shouldBe 1
+        result.roles shouldContain "test-role"
+        result.services shouldContain "test-service"
+        result.actions shouldContain "test-action"
+    }
 
-        result shouldNotBe null
-        result!!.roles.size shouldBe 2
+    "Should accumulate distinct values across multiple addIfAbsent calls" {
+        distinctRolesServicesActionsRepository.addIfAbsent("test-role", "test-service", "test-action")
+        distinctRolesServicesActionsRepository.addIfAbsent("different-role", "test-service", "test-action")
+        distinctRolesServicesActionsRepository.addIfAbsent("test-role", "different-service", "test-action")
+        distinctRolesServicesActionsRepository.addIfAbsent("test-role", "test-service", "different-action")
+
+        val result = distinctRolesServicesActionsRepository.getAll()
+        result.roles.size shouldBe 2
         result.services.size shouldBe 2
         result.actions.size shouldBe 2
         result.roles shouldContain "different-role"
@@ -29,74 +40,44 @@ class DistinctRolesServicesActionsRepositoryTest : RepositoryTestBase({
         result.actions shouldContain "different-action"
     }
 
-    "Should contain new role" {
-        buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository)
+    "Should not duplicate values on repeated addIfAbsent calls" {
+        distinctRolesServicesActionsRepository.addIfAbsent("test-role", "test-service", "test-action")
+        distinctRolesServicesActionsRepository.addIfAbsent("test-role", "test-service", "test-action")
 
-        var result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-        result shouldBe null
-
-        distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions()
-        result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-
-        result shouldNotBe null
-        result!!.roles.size shouldBe 2
-        result.services.size shouldBe 2
-        result.actions.size shouldBe 2
-        result.roles shouldContain "different-role"
-        result.services shouldContain "different-service"
-        result.actions shouldContain "different-action"
-
-        ebmsMessageDetailRepository.insert(buildTestEbmsMessageDetail().copy(fromRole = "another-role"))
-        distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions()
-        result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-
-        result shouldNotBe null
-        result!!.roles.size shouldBe 3
-        result.services.size shouldBe 2
-        result.actions.size shouldBe 2
-        result.roles shouldContain "another-role"
+        val result = distinctRolesServicesActionsRepository.getAll()
+        result.roles.size shouldBe 1
+        result.services.size shouldBe 1
+        result.actions.size shouldBe 1
     }
 
-    "Should contain roles, services and actions in alphabetical order" {
-        buildAndInsertTestEbmsMessageDetailFilterData(ebmsMessageDetailRepository)
+    "Should handle null role in addIfAbsent" {
+        distinctRolesServicesActionsRepository.addIfAbsent(null, "test-service", "test-action")
 
-        var result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-        result shouldBe null
+        val result = distinctRolesServicesActionsRepository.getAll()
+        result.roles shouldBe emptyList()
+        result.services shouldContain "test-service"
+        result.actions shouldContain "test-action"
+    }
 
-        distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions()
-        result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
+    "Should return values sorted alphabetically ignoring case" {
+        distinctRolesServicesActionsRepository.addIfAbsent("test-role", "test-service", "Test-action")
+        distinctRolesServicesActionsRepository.addIfAbsent("another-role", "Another-service", "another-action")
+        distinctRolesServicesActionsRepository.addIfAbsent("Beta-role", "beta-service", "beta-action")
 
-        result shouldNotBe null
-        result!!.roles.size shouldBe 2
-        result.services.size shouldBe 2
-        result.actions.size shouldBe 2
-        result.roles shouldContain "different-role"
-        result.services shouldContain "different-service"
-        result.actions shouldContain "different-action"
+        val result = distinctRolesServicesActionsRepository.getAll()
+        result.roles.size shouldBe 3
+        result.roles shouldContainInOrder listOf("another-role", "Beta-role", "test-role")
+        result.services shouldContainInOrder listOf("Another-service", "beta-service", "test-service")
+        result.actions shouldContainInOrder listOf("another-action", "beta-action", "Test-action")
+    }
 
-        ebmsMessageDetailRepository.insert(buildTestEbmsMessageDetail().copy(fromRole = "another-role"))
-        distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions()
-        result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-
-        result shouldNotBe null
-        result!!.roles.size shouldBe 3
-        result.services.size shouldBe 2
-        result.actions.size shouldBe 2
-        result.roles shouldContain "another-role"
-
-        ebmsMessageDetailRepository.insert(buildTestEbmsMessageDetail().copy(service = "another-service", action = "another-action"))
-        distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions()
-        result = distinctRolesServicesActionsRepository.getDistinctRolesServicesActions()
-
-        result shouldNotBe null
-        result!!.roles.size shouldBe 3
-        result.services.size shouldBe 3
-        result.actions.size shouldBe 3
-        result.services shouldContain "another-service"
-        result.actions shouldContain "another-action"
-
-        result.roles shouldContainInOrder listOf("another-role", "different-role", "test-from-role")
-        result.services shouldContainInOrder listOf("another-service", "different-service", "test-service")
-        result.actions shouldContainInOrder listOf("another-action", "different-action", "test-action")
+    "initialize() should reload values from DB into the in-memory cache" {
+        distinctRolesServicesActionsRepository.addIfAbsent("test-role", "test-service", "test-action")
+        // Calling initialize() again should re-load from DB without losing values
+        distinctRolesServicesActionsRepository.initialize()
+        val result = distinctRolesServicesActionsRepository.getAll()
+        result.roles shouldContain "test-role"
+        result.services shouldContain "test-service"
+        result.actions shouldContain "test-action"
     }
 })

--- a/src/test/kotlin/no/nav/emottak/eventmanager/repository/RepositoryTestBase.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/repository/RepositoryTestBase.kt
@@ -65,9 +65,10 @@ abstract class RepositoryTestBase(
         db.dataSource.connection.use { conn ->
             conn.createStatement().execute("DELETE FROM events")
             conn.createStatement().execute("DELETE FROM ebms_message_details")
-            conn.createStatement().execute("DELETE FROM distict_roles_services_actions")
+            conn.createStatement().execute("DELETE FROM distinct_roles_services_actions")
             conn.createStatement().execute("DELETE FROM conversation_status")
         }
+        distinctRolesServicesActionsRepository.initialize()
     }
 
     init {
@@ -168,7 +169,10 @@ suspend fun buildAndInsertTestEbmsMessageDetailFindData(repository: EbmsMessageD
     return listOf(messageDetailsInInterval1, messageDetailsInInterval2, messageDetailsOutOfInterval1, messageDetailsOutOfInterval2)
 }
 
-suspend fun buildAndInsertTestEbmsMessageDetailFilterData(repository: EbmsMessageDetailRepository) {
+suspend fun buildAndInsertTestEbmsMessageDetailFilterData(
+    repository: EbmsMessageDetailRepository,
+    distinctRolesServicesActionsRepository: DistinctRolesServicesActionsRepository? = null
+) {
     val messageDetails1 = buildTestEbmsMessageDetail()
     val messageDetails2 = buildTestEbmsMessageDetail().copy(
         fromRole = "different-role"
@@ -184,6 +188,12 @@ suspend fun buildAndInsertTestEbmsMessageDetailFilterData(repository: EbmsMessag
     repository.insert(messageDetails2)
     repository.insert(messageDetails3)
     repository.insert(messageDetails4)
+
+    if (distinctRolesServicesActionsRepository != null) {
+        listOf(messageDetails1, messageDetails2, messageDetails3, messageDetails4).forEach { md ->
+            distinctRolesServicesActionsRepository.addIfAbsent(md.fromRole, md.service, md.action)
+        }
+    }
 }
 
 suspend fun buildAndInsertTestEbmsMessageDetailsForConversation(

--- a/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailServiceTest.kt
+++ b/src/test/kotlin/no/nav/emottak/eventmanager/service/EbmsMessageDetailServiceTest.kt
@@ -2,10 +2,14 @@ package no.nav.emottak.eventmanager.service
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.serialization.json.Json
 import no.nav.emottak.eventmanager.model.EbmsMessageDetail
 import no.nav.emottak.eventmanager.model.EventType
@@ -32,7 +36,7 @@ class EbmsMessageDetailServiceTest : StringSpec({
     val eventRepository = mockk<EventRepository>()
     val ebmsMessageDetailRepository = mockk<EbmsMessageDetailRepository>()
     val eventTypeRepository = mockk<EventTypeRepository>(relaxed = true)
-    val distinctRolesServicesActionsRepository = mockk<DistinctRolesServicesActionsRepository>()
+    val distinctRolesServicesActionsRepository = mockk<DistinctRolesServicesActionsRepository>(relaxed = true)
     val conversationStatusRepository = mockk<ConversationStatusRepository>()
     val ebmsMessageDetailService = EbmsMessageDetailService(
         eventRepository,
@@ -428,30 +432,39 @@ class EbmsMessageDetailServiceTest : StringSpec({
         result[2].readableIdList shouldBe testDetails3.generateReadableId()
     }
 
-    "Should retrieve filter-values" {
+    "Should retrieve filter-values via getAll()" {
         val filters = DistinctRolesServicesActionsDto(
             roles = listOf("roleA", "roleB"),
             services = listOf("servicesA", "servicesB"),
-            actions = listOf("actionA", "actionB"),
-            refreshedAt = Instant.now()
+            actions = listOf("actionA", "actionB")
         )
-        coEvery { distinctRolesServicesActionsRepository.getDistinctRolesServicesActions() } returns filters
+        every { distinctRolesServicesActionsRepository.getAll() } returns filters
         val reply = ebmsMessageDetailService.getDistinctRolesServicesActions()
-        coVerify(exactly = 1) { distinctRolesServicesActionsRepository.getDistinctRolesServicesActions() }
+        verify(exactly = 1) { distinctRolesServicesActionsRepository.getAll() }
         reply shouldBe filters
     }
 
-    "Should call refreshDistinctRolesServicesActions() if getDistinctRolesServicesActions() returns null" {
-        val filters = DistinctRolesServicesActionsDto(
-            roles = listOf("roleA", "roleB"),
-            services = listOf("servicesA", "servicesB"),
-            actions = listOf("actionA", "actionB"),
-            refreshedAt = Instant.now()
+    "Should call addIfAbsent during process()" {
+        val testTransportMessageDetail = buildTestTransportMessageDetail()
+        val testDetailsJson = Json.encodeToString(
+            no.nav.emottak.utils.kafka.model.EbmsMessageDetail.serializer(),
+            testTransportMessageDetail
         )
-        coEvery { distinctRolesServicesActionsRepository.getDistinctRolesServicesActions() } returns null
-        coEvery { distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions() } returns filters
-        ebmsMessageDetailService.getDistinctRolesServicesActions()
-        coVerify(exactly = 1) { distinctRolesServicesActionsRepository.refreshDistinctRolesServicesActions() }
+        val testDetails = EbmsMessageDetail.fromTransportModel(testTransportMessageDetail)
+
+        coEvery { ebmsMessageDetailRepository.insert(testDetails) } returns testDetails.requestId
+        coEvery { distinctRolesServicesActionsRepository.addIfAbsent(any(), any(), any()) } just Runs
+        coEvery { conversationStatusRepository.insert(testDetails.conversationId, any()) } returns true
+
+        ebmsMessageDetailService.process(testDetailsJson.toByteArray())
+
+        coVerify(exactly = 1) {
+            distinctRolesServicesActionsRepository.addIfAbsent(
+                testDetails.fromRole,
+                testDetails.service,
+                testDetails.action
+            )
+        }
     }
 
     "isDuplicate should return true when message is a duplicate" {


### PR DESCRIPTION
Har sammen med copilot redesignet henting og lagring av unike roller/services/actions.

Oppgave: https://github.com/navikt/team-emottak-docs/issues/357

I denne løsningen kjøres ikke `SELECT distinct...` hver time på den gigantiske tabellen `ebms_message_details` slik som tidligere. Dette timer idag ut i `PROD`. Nå vil tabellen `distinct_roles_services_actions` oppdateres etter en insert i `ebms_message_details` _hvis_ denne inneholder en unik `from_role`/`service`/`action`.

Copilot ville kjøre `SELECT distinct...` i migreringen for å populere tabellen, men det vil ta for lang tid frykter jeg. Derfor hentes data fra den gamle tabellen `distict_roles_services_actions` (skrivefeil i disti**n**ct). Applikasjonen henter fra DB ved oppstart, og holder de unike rollene/servicene/actions i minnet.

Når en unik rolle, service og/eller action legges inn i `distinct_roles_services_actions`-tabellen, hentes alle dataene på nytt til minne i applikasjonen.

**Til vurdering:** Er det behov for å tvinge henting av roller/services/actions på nytt fra DB?