### PR TITLE
Økt jobNr til prosedyrejobbene - for å trigge rekjøring

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
@@ -97,9 +97,9 @@ suspend fun ResourceScope.runServer() {
 
     val procedures = listOf(
         // Increase jobNr if a job need to be rerun
-        ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerEgenandelFritak"), 2),
-        ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerFrikort"), 2),
-        ProcedureJob("events_cleanup", ProcedureArgs.CleanupArgs(2), 2)
+        ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerEgenandelFritak"), 3),
+        ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerFrikort"), 3),
+        ProcedureJob("events_cleanup", ProcedureArgs.CleanupArgs(2), 3)
     )
     coroutineScope(currentCoroutineContext()).launch {
         runSequentialDelayedTasks(jobStatusRepository, config.delayedJobs.delayInMinutes.minutes, procedures)


### PR DESCRIPTION
Øker `jobNr` til `3` på alle tre procedyrejobbene slik at de trigges ved neste deploy.

De to første jobbene burde ikke finne noen events å slette lenger, men en ny kjøring vil verifisere dette. Den tredje jobben (`events_cleanup`) burde nå klare å kjøre uten å få timeout.

Er en del av oppgaven https://github.com/navikt/team-emottak-docs/issues/342 (sees i sammenheng med PR https://github.com/navikt/emottak-event-manager/pull/69).