### PR TITLE
Rekjøring av events_cleanup-prosedyren

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
@@ -98,9 +98,9 @@ suspend fun ResourceScope.runServer() {
 
     val procedures = listOf(
         // Increase jobNr if a job need to be rerun
-        ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerEgenandelFritak"), 3),
-        ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerFrikort"), 3),
-        ProcedureJob("events_cleanup", ProcedureArgs.CleanupArgs(2), 3)
+        ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerEgenandelFritak"), jobNr = 3),
+        ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerFrikort"), jobNr = 3),
+        ProcedureJob("events_cleanup", ProcedureArgs.CleanupArgs(2), jobNr = 4)
     )
     coroutineScope(currentCoroutineContext()).launch {
         runSequentialDelayedTasks(jobStatusRepository, config.delayedJobs.delayInMinutes.minutes, procedures)


### PR DESCRIPTION
Kjøring av `events_cleanup`-prosedyren tar tid, og da jeg sist sjekket (mandag 1. juni) var det omtrent 165 millioner rader i `events`-tabellen.

Sletteprosedyren hadde slettet nesten 10 millioner av disse da den plutselig stoppet å kjøre (`completed_at` er null):
| job_name | started_at | updated_at | completed_at | result_text |
| -------- | ---------- | ---------- | ------------ | ----------- |
| events_cleanup() 3 | 2026-06-01 10:26:40.793093 | 2026-06-01 11:52:52.171047 | null | 9890000 events deleted |

Loggen skrev aldri ut noen "Task completed", men det viser seg at en ny deploy av `emottak-event-manager` ble trigget noen minutter før siste `updated_at`. Dette betyr at vi ikke kan kjøre nye deploys mens en større prosedyre kjører, for da vil den bli avbrutt.

I denne PR gjør jeg ingenting for å løse det, men bare øker `jobNr` til 4, slik at en ny kjøring av prosedyren blir trigget.

Denne er en del av følgende oppgave: https://github.com/navikt/team-emottak-docs/issues/342