### PR TITLE
Rekjøring av events_cleanup-prosedyren - igjen

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/App.kt
@@ -100,7 +100,7 @@ suspend fun ResourceScope.runServer() {
         // Increase jobNr if a job need to be rerun
         ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerEgenandelFritak"), jobNr = 3),
         ProcedureJob("delete_service_events", ProcedureArgs.DeleteServiceArgs("HarBorgerFrikort"), jobNr = 3),
-        ProcedureJob("events_cleanup", ProcedureArgs.CleanupArgs(2), jobNr = 4)
+        ProcedureJob("events_cleanup", ProcedureArgs.CleanupArgs(2), jobNr = 5)
     )
     coroutineScope(currentCoroutineContext()).launch {
         runSequentialDelayedTasks(jobStatusRepository, config.delayedJobs.delayInMinutes.minutes, procedures)


### PR DESCRIPTION
**Oppgave**
https://github.com/navikt/team-emottak-docs/issues/342

**Bakgrunn**
Prosedyren `events_cleanup` er en prosedyre som skal slette foreldreløse hendelser fra `events`-tabellen. "Foreldreløs" betyr i denne sammenhengen at `request_id` refererer til en ikke-eksisterende rad i `ebms_message_details`-tabellen.

[Forrige kjøring](https://github.com/navikt/emottak-event-manager/pull/73) av `events_cleanup`-prosedyren slettet 134 millioner rader fra `events`-tabellen, og det var vel ca 165 millioner rader totalt før kjøringen. En fersk `count`-spørring avslører at det nå finnes totalt 24,9 millioner rader i `events`-tabellen i prod.

Men den kjørte ikke ferdig. Av en eller annen grunn dukket følgende feilmelding opp etter et drøyt døgns kjøring:
```
org.postgresql.util.PSQLException: ERROR: permission denied for table job_status
  Where: SQL statement "UPDATE job_status SET updated_at = NOW(), result_text = v_result_text WHERE job_name = p_job_name"
```
Og det finnes fortsatt foreldreløse hendelser i `events`-tabellen (spørringen viser de 100 første foreldreløse hendelsene som er minst 2 timer gammel):
```sql
SELECT e.event_id, e.request_id, e.created_at, et.description
FROM events e, event_types et
WHERE e.created_at < (NOW() - (2 || ' hours')::INTERVAL)
  AND NOT EXISTS (
    SELECT 1 FROM ebms_message_details m WHERE m.request_id = e.request_id
)
AND et.event_type_id = e.event_type_id
LIMIT 100;
```

**Endring**
I og med at `UPDATE`-spørringen kjørte OK utallige ganger før den plutselig fikk feilen, så øker jeg bare `jobNr` med 1 slik at prosedyren blir trigget på nytt. Skulle det feile på nytt, må vi se nærmere på problemet.