### PR TITLE
Eksplisitt kotlin.uuid.Uuid.toString for korrekt logging med logstash

### DIFF
--- a/src/main/kotlin/no/nav/emottak/eventmanager/model/EbmsMessageDetail.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/model/EbmsMessageDetail.kt
@@ -44,7 +44,7 @@ data class EbmsMessageDetail(
 
     val marker: LogstashMarker = Markers.appendEntries(
         mapOf(
-            X_REQUEST_ID to this.requestId,
+            X_REQUEST_ID to this.requestId.toString(),
             MESSAGE_ID to this.messageId,
             CONVERSATION_ID to this.conversationId,
             CPA_ID to this.cpaId,

--- a/src/main/kotlin/no/nav/emottak/eventmanager/model/Event.kt
+++ b/src/main/kotlin/no/nav/emottak/eventmanager/model/Event.kt
@@ -22,7 +22,7 @@ data class Event(
 
     val marker: LogstashMarker = Markers.appendEntries(
         mapOf(
-            X_REQUEST_ID to this.requestId,
+            X_REQUEST_ID to this.requestId.toString(),
             MESSAGE_ID to this.messageId,
             CONVERSATION_ID to this.conversationId
         )


### PR DESCRIPTION
Logstash støtter ikke `kotlin.uuid.Uuid` direkte, så dukker logging av`requestId` opp slik i Loki:

`"requestId":{"mostSignificantBits":-6497961996532169420,"leastSignificantBits":-5408375653334957103}`

Slenger på en `toString()` som gjør at den får korrekt UUID format.